### PR TITLE
fix: default pr body and suppress gh help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ By default, dig targets the branch's tracked parent as the PR base. Root branche
 
 If the branch is not pushed to a resolvable remote yet, `dig pr` prompts before running `git push -u <remote> <branch>` and then continues with PR creation if you confirm.
 
-When dig creates a pull request, it prints both the creation summary and the GitHub link.
+When dig creates a pull request, it prints both the creation summary and the GitHub link. If you pass
+`--title` without `--body`, dig reuses the title as the PR body.
 
 `dig tree` annotates tracked branches that have a PR with `(#123)`.
 

--- a/src/cli/pr/mod.rs
+++ b/src/cli/pr/mod.rs
@@ -102,6 +102,9 @@ fn execute_current(args: PrArgs) -> io::Result<CommandOutcome> {
                 "Created pull request #{} for '{}' into '{}'.",
                 outcome.pull_request.number, outcome.branch_name, outcome.base_branch_name
             );
+            if let Some(url) = outcome.created_pull_request_url.as_deref() {
+                println!("{url}");
+            }
         }
         PrOutcomeKind::Adopted => {
             println!(

--- a/src/core/gh.rs
+++ b/src/core/gh.rs
@@ -51,6 +51,7 @@ pub struct CreatePullRequestOptions {
 pub struct CreatedPullRequest {
     pub number: u64,
     pub url: String,
+    pub display_url_in_dig: bool,
 }
 
 #[derive(Debug)]
@@ -62,15 +63,7 @@ struct GhCommandOutput {
 
 impl GhCommandOutput {
     fn combined_output(&self) -> String {
-        let stdout = self.stdout.trim();
-        let stderr = self.stderr.trim();
-
-        match (stdout.is_empty(), stderr.is_empty()) {
-            (true, true) => String::new(),
-            (false, true) => stdout.to_string(),
-            (true, false) => stderr.to_string(),
-            (false, false) => format!("{stdout}\n{stderr}"),
-        }
+        combine_command_output(&self.stdout, &self.stderr)
     }
 }
 
@@ -128,28 +121,13 @@ pub fn list_open_pull_requests_for_head(branch_name: &str) -> io::Result<Vec<Pul
 }
 
 pub fn create_pull_request(options: &CreatePullRequestOptions) -> io::Result<CreatedPullRequest> {
-    let mut args = vec![
-        "pr".to_string(),
-        "create".to_string(),
-        "--base".to_string(),
-        options.base_branch_name.clone(),
-    ];
-
-    if let Some(title) = &options.title {
-        args.push("--title".to_string());
-        args.push(title.clone());
-    }
-
-    if let Some(body) = &options.body {
-        args.push("--body".to_string());
-        args.push(body.clone());
-    }
-
-    if options.draft {
-        args.push("--draft".to_string());
-    }
-
-    let output = run_gh_with_live_output(&args)?;
+    let args = build_create_pull_request_args(options);
+    let display_url_in_dig = options.title.is_some() || options.body.is_some();
+    let output = if display_url_in_dig {
+        run_gh_capture_output(&args)?
+    } else {
+        run_gh_with_live_output(&args)?
+    };
     if !output.status.success() {
         return Err(gh_command_failed(
             "gh pr create",
@@ -163,10 +141,16 @@ pub fn create_pull_request(options: &CreatePullRequestOptions) -> io::Result<Cre
     })?;
 
     if let Some(number) = pull_request_number_from_url(&url) {
-        return Ok(CreatedPullRequest { number, url });
+        return Ok(CreatedPullRequest {
+            number,
+            url,
+            display_url_in_dig,
+        });
     }
 
-    view_pull_request_by_url(&url)
+    let mut created_pull_request = view_pull_request_by_url(&url)?;
+    created_pull_request.display_url_in_dig = display_url_in_dig;
+    Ok(created_pull_request)
 }
 
 pub fn view_pull_request(number: u64) -> io::Result<PullRequestStatus> {
@@ -276,6 +260,7 @@ fn view_pull_request_by_url(url: &str) -> io::Result<CreatedPullRequest> {
     Ok(CreatedPullRequest {
         number: record.number,
         url: record.url,
+        display_url_in_dig: false,
     })
 }
 
@@ -323,6 +308,30 @@ fn parse_pull_request_status(stdout: &str) -> io::Result<PullRequestStatus> {
     })
 }
 
+fn build_create_pull_request_args(options: &CreatePullRequestOptions) -> Vec<String> {
+    let mut args = vec![
+        "pr".to_string(),
+        "create".to_string(),
+        "--base".to_string(),
+        options.base_branch_name.clone(),
+    ];
+
+    if let Some(title) = &options.title {
+        args.push("--title".to_string());
+        args.push(title.clone());
+    }
+
+    if let Some(body) = &options.body {
+        args.push("--body".to_string());
+        args.push(body.clone());
+    }
+
+    if options.draft {
+        args.push("--draft".to_string());
+    }
+
+    args
+}
 fn find_pull_request_url(output: &str) -> Option<String> {
     output
         .split_whitespace()
@@ -454,22 +463,43 @@ fn normalize_gh_spawn_error(err: io::Error) -> io::Error {
 }
 
 fn gh_command_failed(command_name: &str, stdout: &str, stderr: &str) -> io::Error {
-    let combined = match (stdout.trim().is_empty(), stderr.trim().is_empty()) {
-        (true, true) => String::new(),
-        (false, true) => stdout.trim().to_string(),
-        (true, false) => stderr.trim().to_string(),
-        (false, false) => format!("{}\n{}", stdout.trim(), stderr.trim()),
-    };
+    let combined = combine_command_output(stdout, stderr);
 
     if looks_like_auth_error(&combined) {
         return io::Error::other("gh authentication failed; run 'gh auth login'");
     }
 
-    if combined.is_empty() {
+    let sanitized = sanitize_gh_failure_output(&combined);
+    if sanitized.is_empty() {
         io::Error::other(format!("{command_name} failed"))
     } else {
-        io::Error::other(format!("{command_name} failed: {combined}"))
+        io::Error::other(format!("{command_name} failed: {sanitized}"))
     }
+}
+
+fn combine_command_output(stdout: &str, stderr: &str) -> String {
+    let stdout = stdout.trim();
+    let stderr = stderr.trim();
+
+    match (stdout.is_empty(), stderr.is_empty()) {
+        (true, true) => String::new(),
+        (false, true) => stdout.to_string(),
+        (true, false) => stderr.to_string(),
+        (false, false) => format!("{stdout}\n{stderr}"),
+    }
+}
+
+fn sanitize_gh_failure_output(output: &str) -> String {
+    let mut lines = Vec::new();
+
+    for line in output.lines() {
+        if line.trim_start().starts_with("Usage:") {
+            break;
+        }
+        lines.push(line);
+    }
+
+    lines.join("\n").trim().to_string()
 }
 
 fn looks_like_auth_error(message: &str) -> bool {
@@ -483,8 +513,9 @@ fn looks_like_auth_error(message: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        PullRequestState, find_pull_request_url, parse_open_pull_request_details,
-        parse_open_pull_requests, parse_pull_request_status, pull_request_number_from_url,
+        CreatePullRequestOptions, PullRequestState, build_create_pull_request_args,
+        find_pull_request_url, parse_open_pull_request_details, parse_open_pull_requests,
+        parse_pull_request_status, pull_request_number_from_url, sanitize_gh_failure_output,
     };
 
     #[test]
@@ -542,5 +573,39 @@ mod tests {
             pull_request_number_from_url("https://github.com/acme/dig/issues/456"),
             None
         );
+    }
+
+    #[test]
+    fn builds_create_pull_request_args_from_options() {
+        let args = build_create_pull_request_args(&CreatePullRequestOptions {
+            base_branch_name: "main".into(),
+            title: Some("feat: auth".into()),
+            body: Some("feat: auth".into()),
+            draft: true,
+        });
+
+        assert_eq!(
+            args,
+            vec![
+                "pr",
+                "create",
+                "--base",
+                "main",
+                "--title",
+                "feat: auth",
+                "--body",
+                "feat: auth",
+                "--draft",
+            ]
+        );
+    }
+
+    #[test]
+    fn strips_usage_block_from_gh_failure_output() {
+        let sanitized = sanitize_gh_failure_output(
+            "must provide `--title` and `--body`\n\nUsage:  gh pr create [flags]\n\nFlags:\n  -b, --body string\n",
+        );
+
+        assert_eq!(sanitized, "must provide `--title` and `--body`");
     }
 }

--- a/src/core/pr.rs
+++ b/src/core/pr.rs
@@ -22,6 +22,17 @@ pub struct PrOptions {
     pub push_if_needed: bool,
 }
 
+impl PrOptions {
+    fn create_pull_request_options(&self, base_branch_name: String) -> CreatePullRequestOptions {
+        CreatePullRequestOptions {
+            base_branch_name,
+            title: self.title.clone(),
+            body: self.body.clone().or_else(|| self.title.clone()),
+            draft: self.draft,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PrOutcomeKind {
     AlreadyTracked,
@@ -36,6 +47,7 @@ pub struct PrOutcome {
     pub branch_name: String,
     pub base_branch_name: String,
     pub pull_request: TrackedPullRequest,
+    pub created_pull_request_url: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -111,6 +123,7 @@ pub fn run(options: &PrOptions) -> io::Result<PrOutcome> {
             branch_name,
             base_branch_name,
             pull_request,
+            created_pull_request_url: None,
         });
     }
 
@@ -142,12 +155,9 @@ pub fn run(options: &PrOptions) -> io::Result<PrOutcome> {
                 }
             }
 
-            let created_pull_request = gh::create_pull_request(&CreatePullRequestOptions {
-                base_branch_name: base_branch_name.clone(),
-                title: options.title.clone(),
-                body: options.body.clone(),
-                draft: options.draft,
-            })?;
+            let created_pull_request = gh::create_pull_request(
+                &options.create_pull_request_options(base_branch_name.clone()),
+            )?;
             let pull_request = TrackedPullRequest {
                 number: created_pull_request.number,
             };
@@ -166,6 +176,9 @@ pub fn run(options: &PrOptions) -> io::Result<PrOutcome> {
                 branch_name,
                 base_branch_name,
                 pull_request,
+                created_pull_request_url: created_pull_request
+                    .display_url_in_dig
+                    .then_some(created_pull_request.url),
             })
         }
         PrTrackingAction::Adopt(existing_pull_request) => {
@@ -187,6 +200,7 @@ pub fn run(options: &PrOptions) -> io::Result<PrOutcome> {
                 branch_name,
                 base_branch_name,
                 pull_request,
+                created_pull_request_url: None,
             })
         }
     }
@@ -407,9 +421,10 @@ fn collect_pull_requests_in_order(
 #[cfg(test)]
 mod tests {
     use super::{
-        PrTrackingAction, TrackedPullRequestListNode, build_pull_request_list_nodes,
+        PrOptions, PrTrackingAction, TrackedPullRequestListNode, build_pull_request_list_nodes,
         collect_pull_requests_in_order, resolve_tracking_action,
     };
+    use crate::core::gh::CreatePullRequestOptions;
     use crate::core::gh::PullRequestDetails;
     use crate::core::gh::PullRequestSummary;
     use crate::core::tree::TreeNode;
@@ -420,6 +435,27 @@ mod tests {
         let action = resolve_tracking_action("feat/auth", "main", &[]).unwrap();
 
         assert_eq!(action, PrTrackingAction::Create);
+    }
+
+    #[test]
+    fn defaults_create_body_to_title_when_body_is_absent() {
+        let create_options = PrOptions {
+            title: Some("feat: auth".into()),
+            body: None,
+            draft: true,
+            push_if_needed: false,
+        }
+        .create_pull_request_options("main".into());
+
+        assert_eq!(
+            create_options,
+            CreatePullRequestOptions {
+                base_branch_name: "main".into(),
+                title: Some("feat: auth".into()),
+                body: Some("feat: auth".into()),
+                draft: true,
+            }
+        );
     }
 
     #[test]

--- a/tests/pr.rs
+++ b/tests/pr.rs
@@ -227,6 +227,56 @@ exit 1
 }
 
 #[test]
+fn pr_defaults_body_to_title_when_body_is_omitted() {
+    with_temp_repo("dig-pr-cli", |repo| {
+        initialize_main_repo(repo);
+        dig_ok(repo, &["init"]);
+        dig_ok(repo, &["branch", "feat/auth"]);
+
+        let (_, path, log_path) = install_fake_gh(
+            repo,
+            r#"#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$DIG_TEST_GH_LOG"
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  printf '[]\n'
+  exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  printf 'https://github.com/acme/dig/pull/321\n'
+  exit 0
+fi
+echo "unexpected gh args: $*" >&2
+exit 1
+"#,
+        );
+
+        let output = dig_ok_with_env(
+            repo,
+            &["pr", "--title", "feat-auth", "--draft"],
+            &[
+                ("PATH", path.as_str()),
+                ("DIG_TEST_GH_LOG", log_path.as_str()),
+            ],
+        );
+        let stdout = strip_ansi(&String::from_utf8(output.stdout).unwrap());
+
+        assert!(stdout.contains("Created pull request #321 for 'feat/auth' into 'main'."));
+        assert_eq!(
+            stdout
+                .matches("https://github.com/acme/dig/pull/321")
+                .count(),
+            1
+        );
+
+        let gh_log = fs::read_to_string(log_path).unwrap();
+        assert!(
+            gh_log.contains("pr create --base main --title feat-auth --body feat-auth --draft")
+        );
+    });
+}
+
+#[test]
 fn pr_adopts_matching_open_pull_request_without_creating_another() {
     with_temp_repo("dig-pr-cli", |repo| {
         initialize_main_repo(repo);
@@ -452,7 +502,7 @@ exit 1
             vec![
                 "pr list --head feat/auth --state open --json number,baseRefName,url",
                 "pr list --head feat/auth --state open --json number,baseRefName,url",
-                "pr create --base main --title feat-auth",
+                "pr create --base main --title feat-auth --body feat-auth",
                 "pr view 123 --web",
             ]
         );
@@ -832,5 +882,67 @@ fn pr_reports_missing_gh_cli() {
         assert!(!output.status.success());
         let stderr = String::from_utf8(output.stderr).unwrap();
         assert!(stderr.contains("gh CLI is not installed or not found on PATH"));
+    });
+}
+
+#[test]
+fn pr_hides_gh_usage_output_when_create_fails() {
+    with_temp_repo("dig-pr-cli", |repo| {
+        initialize_main_repo(repo);
+        dig_ok(repo, &["init"]);
+        dig_ok(repo, &["branch", "feat/auth"]);
+
+        let (_, path, log_path) = install_fake_gh(
+            repo,
+            r#"#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$DIG_TEST_GH_LOG"
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  printf '[]\n'
+  exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  cat >&2 <<'EOF'
+must provide `--title` and `--body` (or `--fill`)
+
+Usage:  gh pr create [flags]
+
+Flags:
+  -b, --body string
+EOF
+  exit 1
+fi
+echo "unexpected gh args: $*" >&2
+exit 1
+"#,
+        );
+
+        let output = support::dig_with_env(
+            repo,
+            &["pr", "--title", "feat-auth", "--draft"],
+            &[
+                ("PATH", path.as_str()),
+                ("DIG_TEST_GH_LOG", log_path.as_str()),
+            ],
+        );
+
+        assert!(!output.status.success());
+        assert!(String::from_utf8(output.stdout).unwrap().trim().is_empty());
+
+        let stderr = String::from_utf8(output.stderr).unwrap();
+        assert_eq!(
+            stderr
+                .matches("must provide `--title` and `--body`")
+                .count(),
+            1
+        );
+        assert!(stderr.contains("gh pr create failed: must provide `--title` and `--body`"));
+        assert!(!stderr.contains("Usage:"));
+        assert!(!stderr.contains("Flags:"));
+
+        let gh_log = fs::read_to_string(log_path).unwrap();
+        assert!(
+            gh_log.contains("pr create --base main --title feat-auth --body feat-auth --draft")
+        );
     });
 }


### PR DESCRIPTION
This pull request improves the user experience and robustness of the `dig pr` command, especially when creating pull requests with the GitHub CLI. The most notable changes are improved handling of the PR body when only a title is provided, cleaner error output by hiding unnecessary usage text from failures, and more precise test coverage for these behaviors.

**User Experience Improvements:**

* When creating a pull request, if the user provides `--title` but omits `--body`, the title is now reused as the PR body. This change is reflected in both the CLI logic and the documentation. [[1]](diffhunk://#diff-cb3cb5e3b5affb76fe97880fe0ef0be04409b668fca28470e03f47eef407b266R25-R35) [[2]](diffhunk://#diff-cb3cb5e3b5affb76fe97880fe0ef0be04409b668fca28470e03f47eef407b266L145-R160) [[3]](diffhunk://#diff-cb3cb5e3b5affb76fe97880fe0ef0be04409b668fca28470e03f47eef407b266R440-R460) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L140-R141)
* The PR creation summary now prints the GitHub link only when appropriate, improving clarity for users. [[1]](diffhunk://#diff-a4b0472011a8f6629d8308b7e03f3943b3a8b130ba900da92a7fda8b28e7f786R105-R107) [[2]](diffhunk://#diff-cb3cb5e3b5affb76fe97880fe0ef0be04409b668fca28470e03f47eef407b266R50) [[3]](diffhunk://#diff-cb3cb5e3b5affb76fe97880fe0ef0be04409b668fca28470e03f47eef407b266R179-R181)

**Error Handling and Output:**

* Error messages from failed `gh pr create` commands now strip out the usage/help block, showing only the relevant error message to the user. This is handled by a new `sanitize_gh_failure_output` function and corresponding changes in error handling. [[1]](diffhunk://#diff-85b04f69ac3082175a8d73d2e024276c6ae0ff03a336f0268ab6fabfc0ab33c0L457-R502) [[2]](diffhunk://#diff-85b04f69ac3082175a8d73d2e024276c6ae0ff03a336f0268ab6fabfc0ab33c0L65-R66) [[3]](diffhunk://#diff-85b04f69ac3082175a8d73d2e024276c6ae0ff03a336f0268ab6fabfc0ab33c0L486-R518) [[4]](diffhunk://#diff-85b04f69ac3082175a8d73d2e024276c6ae0ff03a336f0268ab6fabfc0ab33c0R577-R610) [[5]](diffhunk://#diff-df8a38faffeb235a100a83a40dbc5d38cf6c81aa9ef980c54404770832240c7cR887-R948)

**Codebase Refactoring and Testing:**

* The logic for building CLI arguments for pull request creation has been refactored into a dedicated function, improving maintainability and testability. [[1]](diffhunk://#diff-85b04f69ac3082175a8d73d2e024276c6ae0ff03a336f0268ab6fabfc0ab33c0R311-R334) [[2]](diffhunk://#diff-85b04f69ac3082175a8d73d2e024276c6ae0ff03a336f0268ab6fabfc0ab33c0L131-R130) [[3]](diffhunk://#diff-85b04f69ac3082175a8d73d2e024276c6ae0ff03a336f0268ab6fabfc0ab33c0L166-R153)
* Additional and updated tests ensure the new behaviors are covered, including defaulting the PR body to the title and verifying error output sanitization. [[1]](diffhunk://#diff-df8a38faffeb235a100a83a40dbc5d38cf6c81aa9ef980c54404770832240c7cR229-R278) [[2]](diffhunk://#diff-df8a38faffeb235a100a83a40dbc5d38cf6c81aa9ef980c54404770832240c7cL455-R505) [[3]](diffhunk://#diff-85b04f69ac3082175a8d73d2e024276c6ae0ff03a336f0268ab6fabfc0ab33c0R577-R610) [[4]](diffhunk://#diff-cb3cb5e3b5affb76fe97880fe0ef0be04409b668fca28470e03f47eef407b266L410-R427) [[5]](diffhunk://#diff-df8a38faffeb235a100a83a40dbc5d38cf6c81aa9ef980c54404770832240c7cR887-R948)

These changes collectively enhance the reliability and usability of the `dig pr` workflow, making it more intuitive and user-friendly.