### PR TITLE
fix(sync): sync no longer prompts to delete new branches

### DIFF
--- a/src/core/adopt.rs
+++ b/src/core/adopt.rs
@@ -7,8 +7,9 @@ use crate::core::branch;
 use crate::core::git;
 use crate::core::restack::{RestackAction, RestackBaseTarget};
 use crate::core::store::{
-    BranchNode, ParentRef, PendingAdoptOperation, PendingOperationKind, PendingOperationState,
-    now_unix_timestamp_secs, open_initialized, open_or_initialize, record_branch_adopted,
+    BranchDivergenceState, BranchNode, ParentRef, PendingAdoptOperation, PendingOperationKind,
+    PendingOperationState, now_unix_timestamp_secs, open_initialized, open_or_initialize,
+    record_branch_adopted,
 };
 use crate::core::workflow;
 
@@ -178,9 +179,16 @@ pub fn apply(plan: &AdoptPlan) -> io::Result<AdoptOutcome> {
         branch_name: plan.branch_name.clone(),
         parent: plan.parent.clone(),
         base_ref: plan.parent_branch_name.clone(),
-        fork_point_oid: parent_head_oid,
-        head_oid_at_creation: branch_head_oid,
+        fork_point_oid: parent_head_oid.clone(),
+        head_oid_at_creation: branch_head_oid.clone(),
         created_at_unix_secs: now_unix_timestamp_secs(),
+        divergence_state: if branch_head_oid == parent_head_oid {
+            BranchDivergenceState::NeverDiverged {
+                aligned_head_oid: branch_head_oid,
+            }
+        } else {
+            BranchDivergenceState::Diverged
+        },
         pull_request: None,
         archived: false,
     };
@@ -261,9 +269,16 @@ pub(crate) fn resume_after_sync(
         branch_name: payload.branch_name.clone(),
         parent: payload.parent.clone(),
         base_ref: payload.parent_branch_name.clone(),
-        fork_point_oid: parent_head_oid,
-        head_oid_at_creation: branch_head_oid,
+        fork_point_oid: parent_head_oid.clone(),
+        head_oid_at_creation: branch_head_oid.clone(),
         created_at_unix_secs: now_unix_timestamp_secs(),
+        divergence_state: if branch_head_oid == parent_head_oid {
+            BranchDivergenceState::NeverDiverged {
+                aligned_head_oid: branch_head_oid,
+            }
+        } else {
+            BranchDivergenceState::Diverged
+        },
         pull_request: None,
         archived: false,
     };

--- a/src/core/branch.rs
+++ b/src/core/branch.rs
@@ -8,8 +8,8 @@ use crate::core::graph::BranchGraph;
 use crate::core::graph::BranchLineageNode;
 use crate::core::store::types::DigState;
 use crate::core::store::{
-    BranchNode, DigConfig, ParentRef, now_unix_timestamp_secs, open_or_initialize,
-    record_branch_created,
+    BranchDivergenceState, BranchNode, DigConfig, ParentRef, now_unix_timestamp_secs,
+    open_or_initialize, record_branch_created,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -77,8 +77,11 @@ pub fn run(options: &BranchOptions) -> io::Result<BranchOutcome> {
         parent,
         base_ref: parent_branch_name.clone(),
         fork_point_oid: parent_head_oid.clone(),
-        head_oid_at_creation: parent_head_oid,
+        head_oid_at_creation: parent_head_oid.clone(),
         created_at_unix_secs: now_unix_timestamp_secs(),
+        divergence_state: BranchDivergenceState::NeverDiverged {
+            aligned_head_oid: parent_head_oid,
+        },
         pull_request: None,
         archived: false,
     };
@@ -149,7 +152,7 @@ pub(crate) fn resolve_parent_ref(
 mod tests {
     use super::{BranchOptions, resolve_parent_branch_name, resolve_parent_ref};
     use crate::core::store::types::DigState;
-    use crate::core::store::{BranchNode, DigConfig, ParentRef};
+    use crate::core::store::{BranchDivergenceState, BranchNode, DigConfig, ParentRef};
     use uuid::Uuid;
 
     #[test]
@@ -186,6 +189,7 @@ mod tests {
                 fork_point_oid: "abc123".into(),
                 head_oid_at_creation: "abc123".into(),
                 created_at_unix_secs: 1,
+                divergence_state: BranchDivergenceState::Unknown,
                 pull_request: None,
                 archived: false,
             }],

--- a/src/core/clean/mod.rs
+++ b/src/core/clean/mod.rs
@@ -4,8 +4,8 @@ mod types;
 
 pub(crate) use apply::{apply, apply_with_reporter, resume_after_sync_with_reporter};
 pub(crate) use plan::{
-    CleanPlanMode, branch_is_integrated, cleanup_candidate_for_branch, mode_for_sync, plan,
-    plan_for_resume, plan_for_sync,
+    CleanPlanMode, cleanup_candidate_for_branch, mode_for_sync, plan, plan_for_resume,
+    plan_for_sync, reconcile_branch_divergence_state, tracked_branch_is_integrated,
 };
 pub(crate) use types::{
     BlockedBranch, CleanApplyOutcome, CleanBlockReason, CleanCandidate, CleanEvent, CleanOptions,

--- a/src/core/clean/plan.rs
+++ b/src/core/clean/plan.rs
@@ -5,10 +5,10 @@ use crate::core::deleted_local;
 use crate::core::git::{self, CherryMarker, CommitMetadata};
 use crate::core::graph::BranchGraph;
 use crate::core::restack::{self, RestackBaseTarget};
-use crate::core::store::types::DigState;
+use crate::core::store::types::{BranchDivergenceState, DigState};
 use crate::core::store::{
-    BranchNode, PendingCleanCandidate, PendingCleanCandidateKind, PendingCleanOperation, dig_paths,
-    load_config, load_state,
+    BranchNode, PendingCleanCandidate, PendingCleanCandidateKind, PendingCleanOperation,
+    StoreSession, dig_paths, load_state, open_initialized, save_state,
 };
 use crate::core::workflow;
 
@@ -34,6 +34,41 @@ pub(crate) fn plan(options: &CleanOptions) -> io::Result<CleanPlan> {
 
 pub(crate) fn plan_for_sync() -> io::Result<CleanPlan> {
     plan_with_mode(&CleanOptions::default(), CleanPlanMode::RemoteAwareSync)
+}
+
+pub(crate) fn reconcile_branch_divergence_state(session: &mut StoreSession) -> io::Result<()> {
+    let node_ids = session
+        .state
+        .nodes
+        .iter()
+        .filter(|node| !node.archived)
+        .map(|node| node.id)
+        .collect::<Vec<_>>();
+    let mut changed = false;
+
+    for node_id in node_ids {
+        let Some(node) = session.state.find_branch_by_id(node_id).cloned() else {
+            continue;
+        };
+        let Some(divergence_state) = reconciled_branch_divergence_state(
+            &session.state,
+            &session.config.trunk_branch,
+            &node,
+        )?
+        else {
+            continue;
+        };
+
+        changed |= session
+            .state
+            .set_branch_divergence_state(node_id, divergence_state)?;
+    }
+
+    if changed {
+        save_state(&session.paths, &session.state)?;
+    }
+
+    Ok(())
 }
 
 pub(crate) fn plan_for_resume(payload: &PendingCleanOperation) -> io::Result<CleanPlan> {
@@ -76,11 +111,8 @@ pub(crate) fn mode_for_sync(remote_sync_enabled: bool) -> CleanPlanMode {
 
 fn plan_with_mode(options: &CleanOptions, mode: CleanPlanMode) -> io::Result<CleanPlan> {
     workflow::ensure_no_pending_operation_for_command("clean")?;
-    let repo = git::resolve_repo_context()?;
-    let store_paths = dig_paths(&repo.git_dir);
-    let config = load_config(&store_paths)?
-        .ok_or_else(|| io::Error::other("dig is not initialized; run 'dig init' first"))?;
-    let state = load_state(&store_paths)?;
+    let mut session = open_initialized("dig is not initialized; run 'dig init' first")?;
+    reconcile_branch_divergence_state(&mut session)?;
     let current_branch = git::current_branch_name()?;
     let requested_branch_name = options
         .branch_name
@@ -91,13 +123,18 @@ fn plan_with_mode(options: &CleanOptions, mode: CleanPlanMode) -> io::Result<Cle
 
     match &requested_branch_name {
         Some(branch_name) => plan_for_requested_branch(
-            &state,
-            &config.trunk_branch,
+            &session.state,
+            &session.config.trunk_branch,
             &current_branch,
             branch_name,
             mode,
         ),
-        None => plan_for_all_branches(&state, &config.trunk_branch, &current_branch, mode),
+        None => plan_for_all_branches(
+            &session.state,
+            &session.config.trunk_branch,
+            &current_branch,
+            mode,
+        ),
     }
 }
 
@@ -270,6 +307,15 @@ fn evaluate_integrated_branch(
         }));
     }
 
+    if !matches!(node.divergence_state, BranchDivergenceState::Diverged) {
+        return Ok(BranchEvaluation::Blocked(BlockedBranch {
+            branch_name: node.branch_name.clone(),
+            reason: CleanBlockReason::NotIntegrated {
+                parent_branch: parent_branch_name,
+            },
+        }));
+    }
+
     let tracked_pull_request_number = node.pull_request.as_ref().map(|pr| pr.number);
     let parent_base = if branch_is_integrated_for_pull_request(
         local_parent_base.rebase_ref(),
@@ -399,11 +445,19 @@ fn clean_candidate_from_pending_candidate(
     }
 }
 
-pub(crate) fn branch_is_integrated(
+pub(crate) fn tracked_branch_is_integrated(
+    node: &BranchNode,
     parent_branch_name: &str,
-    branch_name: &str,
 ) -> io::Result<bool> {
-    branch_is_integrated_for_pull_request(parent_branch_name, branch_name, None)
+    if !matches!(node.divergence_state, BranchDivergenceState::Diverged) {
+        return Ok(false);
+    }
+
+    branch_is_integrated_for_pull_request(
+        parent_branch_name,
+        &node.branch_name,
+        node.pull_request.as_ref().map(|pr| pr.number),
+    )
 }
 
 fn branch_is_integrated_for_pull_request(
@@ -443,6 +497,78 @@ fn branch_is_integrated_by_cherry(parent_branch_name: &str, branch_name: &str) -
     Ok(markers
         .into_iter()
         .all(|marker| matches!(marker, CherryMarker::Equivalent)))
+}
+
+fn reconciled_branch_divergence_state(
+    state: &DigState,
+    trunk_branch: &str,
+    node: &BranchNode,
+) -> io::Result<Option<BranchDivergenceState>> {
+    if !git::branch_exists(&node.branch_name)? {
+        return Ok(None);
+    }
+
+    let Ok((parent_base, _)) =
+        deleted_local::resolve_replacement_parent(state, trunk_branch, &node.parent)
+    else {
+        return Ok(None);
+    };
+    if !git::branch_exists(&parent_base.branch_name)? {
+        return Ok(None);
+    }
+
+    let current_head_oid = git::ref_oid(&node.branch_name)?;
+    let desired_state = if branch_has_unique_commits(&parent_base.branch_name, &node.branch_name)? {
+        BranchDivergenceState::Diverged
+    } else {
+        match branch_reflog_indicates_divergence(&node.branch_name) {
+            Ok(true) => BranchDivergenceState::Diverged,
+            Ok(false) => BranchDivergenceState::NeverDiverged {
+                aligned_head_oid: current_head_oid,
+            },
+            Err(_) => match node.divergence_state {
+                BranchDivergenceState::Unknown => return Ok(None),
+                BranchDivergenceState::NeverDiverged { .. } => {
+                    BranchDivergenceState::NeverDiverged {
+                        aligned_head_oid: current_head_oid,
+                    }
+                }
+                BranchDivergenceState::Diverged => BranchDivergenceState::Diverged,
+            },
+        }
+    };
+
+    if node.divergence_state == desired_state {
+        Ok(None)
+    } else {
+        Ok(Some(desired_state))
+    }
+}
+
+fn branch_has_unique_commits(parent_branch_name: &str, branch_name: &str) -> io::Result<bool> {
+    let merge_base = git::merge_base(parent_branch_name, branch_name)?;
+    Ok(!git::commit_metadata_in_range(&format!("{merge_base}..{branch_name}"))?.is_empty())
+}
+
+fn branch_reflog_indicates_divergence(branch_name: &str) -> io::Result<bool> {
+    let reflog_subjects = git::reflog_subjects(branch_name)?;
+
+    Ok(reflog_subjects
+        .into_iter()
+        .any(|subject| reflog_subject_indicates_divergence(&subject)))
+}
+
+fn reflog_subject_indicates_divergence(subject: &str) -> bool {
+    [
+        "commit:",
+        "commit (amend):",
+        "cherry-pick:",
+        "revert:",
+        "merge ",
+        "merge:",
+    ]
+    .iter()
+    .any(|prefix| subject.starts_with(prefix))
 }
 
 fn branch_is_integrated_by_squash_message(

--- a/src/core/clean/tests.rs
+++ b/src/core/clean/tests.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::path::PathBuf;
 
 use super::plan::{
@@ -8,8 +9,8 @@ use super::{BlockedBranch, CleanBlockReason, CleanOptions, CleanReason, apply};
 use crate::core::git::{self, CommitMetadata};
 use crate::core::restack::RestackBaseTarget;
 use crate::core::store::{
-    BranchPullRequestTrackedSource, ParentRef, TrackedPullRequest, dig_paths, load_state,
-    open_initialized, record_branch_pull_request_tracked,
+    BranchDivergenceState, BranchPullRequestTrackedSource, ParentRef, TrackedPullRequest,
+    dig_paths, load_state, open_initialized, record_branch_pull_request_tracked,
 };
 use crate::core::test_support::{
     append_file, commit_file, create_tracked_branch, git_ok, initialize_main_repo,
@@ -120,6 +121,116 @@ fn detects_parent_commit_that_mentions_tracked_pull_request_number() {
         },
         2,
     ));
+}
+
+#[test]
+fn fresh_branch_is_not_cleanable_without_commits() {
+    with_temp_repo("dig-clean", |repo| {
+        initialize_main_repo(repo);
+        create_tracked_branch("feat/auth");
+
+        let plan = build_plan(&CleanOptions {
+            branch_name: Some("feat/auth".into()),
+        })
+        .unwrap();
+
+        assert!(plan.candidates.is_empty());
+        assert_eq!(
+            plan.blocked,
+            vec![BlockedBranch {
+                branch_name: "feat/auth".into(),
+                reason: CleanBlockReason::NotIntegrated {
+                    parent_branch: "main".into(),
+                },
+            }]
+        );
+
+        let repo_context = git::resolve_repo_context().unwrap();
+        let state = load_state(&dig_paths(&repo_context.git_dir)).unwrap();
+        let branch = state.find_branch_by_name("feat/auth").unwrap();
+        assert_eq!(
+            branch.divergence_state,
+            BranchDivergenceState::NeverDiverged {
+                aligned_head_oid: git::ref_oid("feat/auth").unwrap(),
+            }
+        );
+    });
+}
+
+#[test]
+fn rebased_fresh_branch_remains_not_cleanable() {
+    with_temp_repo("dig-clean", |repo| {
+        initialize_main_repo(repo);
+        create_tracked_branch("feat/auth");
+        git_ok(repo, &["checkout", "main"]);
+        commit_file(repo, "README.md", "root\nmain\n", "feat: trunk follow-up");
+        git_ok(repo, &["checkout", "feat/auth"]);
+        git_ok(repo, &["rebase", "main"]);
+
+        let plan = build_plan(&CleanOptions {
+            branch_name: Some("feat/auth".into()),
+        })
+        .unwrap();
+
+        assert!(plan.candidates.is_empty());
+        assert_eq!(
+            plan.blocked,
+            vec![BlockedBranch {
+                branch_name: "feat/auth".into(),
+                reason: CleanBlockReason::NotIntegrated {
+                    parent_branch: "main".into(),
+                },
+            }]
+        );
+
+        let repo_context = git::resolve_repo_context().unwrap();
+        let state = load_state(&dig_paths(&repo_context.git_dir)).unwrap();
+        let branch = state.find_branch_by_name("feat/auth").unwrap();
+        assert_eq!(
+            branch.divergence_state,
+            BranchDivergenceState::NeverDiverged {
+                aligned_head_oid: git::ref_oid("feat/auth").unwrap(),
+            }
+        );
+    });
+}
+
+#[test]
+fn legacy_unknown_branch_with_fast_forwarded_manual_commit_is_cleanable() {
+    with_temp_repo("dig-clean", |repo| {
+        initialize_main_repo(repo);
+        create_tracked_branch("feat/auth");
+        commit_file(repo, "auth.txt", "auth\n", "feat: auth");
+        git_ok(repo, &["checkout", "main"]);
+        git_ok(repo, &["merge", "--ff-only", "feat/auth"]);
+
+        let state_path = repo.join(".git/dig/state.json");
+        let mut state_json =
+            serde_json::from_str::<serde_json::Value>(&fs::read_to_string(&state_path).unwrap())
+                .unwrap();
+        state_json["nodes"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("divergence_state");
+        fs::write(
+            &state_path,
+            serde_json::to_string_pretty(&state_json).unwrap(),
+        )
+        .unwrap();
+
+        let plan = build_plan(&CleanOptions {
+            branch_name: Some("feat/auth".into()),
+        })
+        .unwrap();
+
+        assert_eq!(plan.candidates.len(), 1);
+        assert_eq!(plan.candidates[0].branch_name, "feat/auth");
+
+        let repo_context = git::resolve_repo_context().unwrap();
+        let state = load_state(&dig_paths(&repo_context.git_dir)).unwrap();
+        let branch = state.find_branch_by_name("feat/auth").unwrap();
+        assert_eq!(branch.divergence_state, BranchDivergenceState::Diverged);
+    });
 }
 
 #[test]

--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -4,8 +4,9 @@ use std::process::{Command, ExitStatus};
 use crate::core::git::{self, RepoContext};
 use crate::core::restack::{self, RestackPreview};
 use crate::core::store::{
-    PendingCommitEntry, PendingCommitOperation, PendingOperationKind, PendingOperationState,
-    StoreSession, dig_paths, load_config, load_state, open_initialized,
+    BranchDivergenceState, PendingCommitEntry, PendingCommitOperation, PendingOperationKind,
+    PendingOperationState, StoreSession, dig_paths, load_config, load_state, open_initialized,
+    record_branch_divergence_state,
 };
 use crate::core::workflow;
 
@@ -311,6 +312,7 @@ fn maybe_restack_after_commit_inner(
         config,
         state,
     };
+    record_branch_divergence_state(&mut session, node.id, BranchDivergenceState::Diverged)?;
     let restack_outcome = match workflow::execute_resumable_restack_operation(
         &mut session,
         PendingOperationKind::Commit(PendingCommitOperation {

--- a/src/core/git.rs
+++ b/src/core/git.rs
@@ -339,6 +339,26 @@ pub fn commit_metadata_in_range(range_spec: &str) -> io::Result<Vec<CommitMetada
     Ok(parse_commit_metadata_records(&stdout))
 }
 
+pub fn reflog_subjects(reference: &str) -> io::Result<Vec<String>> {
+    let output = Command::new("git")
+        .args(["reflog", "show", "--format=%gs", reference])
+        .output()?;
+
+    if !output.status.success() {
+        return Err(git_command_failed(&output));
+    }
+
+    let stdout = String::from_utf8(output.stdout)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+
+    Ok(stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
 pub fn branch_push_target_if_needed(branch_name: &str) -> io::Result<Option<BranchPushTarget>> {
     let Some(target) = branch_push_target(branch_name)? else {
         return Ok(None);

--- a/src/core/graph.rs
+++ b/src/core/graph.rs
@@ -161,7 +161,7 @@ impl<'a> BranchGraph<'a> {
 mod tests {
     use super::{BranchGraph, BranchLineageNode, BranchTreeNode};
     use crate::core::store::types::{DIG_STATE_VERSION, DigState};
-    use crate::core::store::{BranchNode, ParentRef, TrackedPullRequest};
+    use crate::core::store::{BranchDivergenceState, BranchNode, ParentRef, TrackedPullRequest};
     use uuid::Uuid;
 
     fn fixture_state() -> (DigState, Uuid, Uuid, Uuid) {
@@ -181,6 +181,7 @@ mod tests {
                         fork_point_oid: "abc123".into(),
                         head_oid_at_creation: "abc123".into(),
                         created_at_unix_secs: 1,
+                        divergence_state: BranchDivergenceState::Unknown,
                         pull_request: Some(TrackedPullRequest { number: 42 }),
                         archived: false,
                     },
@@ -192,6 +193,7 @@ mod tests {
                         fork_point_oid: "def456".into(),
                         head_oid_at_creation: "def456".into(),
                         created_at_unix_secs: 2,
+                        divergence_state: BranchDivergenceState::Unknown,
                         pull_request: None,
                         archived: false,
                     },
@@ -203,6 +205,7 @@ mod tests {
                         fork_point_oid: "fedcba".into(),
                         head_oid_at_creation: "fedcba".into(),
                         created_at_unix_secs: 3,
+                        divergence_state: BranchDivergenceState::Unknown,
                         pull_request: None,
                         archived: false,
                     },

--- a/src/core/restack.rs
+++ b/src/core/restack.rs
@@ -441,7 +441,7 @@ mod tests {
     };
     use crate::core::git;
     use crate::core::store::types::DIG_STATE_VERSION;
-    use crate::core::store::{BranchNode, ParentRef};
+    use crate::core::store::{BranchDivergenceState, BranchNode, ParentRef};
     use crate::core::test_support::{commit_file, git_ok, initialize_main_repo, with_temp_repo};
     use uuid::Uuid;
 
@@ -521,6 +521,7 @@ mod tests {
                         fork_point_oid: "root".into(),
                         head_oid_at_creation: "root".into(),
                         created_at_unix_secs: 1,
+                        divergence_state: BranchDivergenceState::Unknown,
                         pull_request: None,
                         archived: false,
                     },
@@ -532,6 +533,7 @@ mod tests {
                         fork_point_oid: "auth".into(),
                         head_oid_at_creation: "auth".into(),
                         created_at_unix_secs: 2,
+                        divergence_state: BranchDivergenceState::Unknown,
                         pull_request: None,
                         archived: false,
                     },
@@ -543,6 +545,7 @@ mod tests {
                         fork_point_oid: "api".into(),
                         head_oid_at_creation: "api".into(),
                         created_at_unix_secs: 3,
+                        divergence_state: BranchDivergenceState::Unknown,
                         pull_request: None,
                         archived: false,
                     },
@@ -596,6 +599,7 @@ mod tests {
                         fork_point_oid: "root".into(),
                         head_oid_at_creation: "root".into(),
                         created_at_unix_secs: 1,
+                        divergence_state: BranchDivergenceState::Unknown,
                         pull_request: None,
                         archived: false,
                     },
@@ -607,6 +611,7 @@ mod tests {
                         fork_point_oid: deleted_branch_head_oid.clone(),
                         head_oid_at_creation: deleted_branch_head_oid.clone(),
                         created_at_unix_secs: 2,
+                        divergence_state: BranchDivergenceState::Unknown,
                         pull_request: None,
                         archived: false,
                     },
@@ -665,6 +670,7 @@ mod tests {
                         fork_point_oid: "root".into(),
                         head_oid_at_creation: "root".into(),
                         created_at_unix_secs: 1,
+                        divergence_state: BranchDivergenceState::Unknown,
                         pull_request: None,
                         archived: false,
                     },
@@ -676,6 +682,7 @@ mod tests {
                         fork_point_oid: "auth".into(),
                         head_oid_at_creation: "auth".into(),
                         created_at_unix_secs: 2,
+                        divergence_state: BranchDivergenceState::Unknown,
                         pull_request: None,
                         archived: false,
                     },
@@ -687,6 +694,7 @@ mod tests {
                         fork_point_oid: "api".into(),
                         head_oid_at_creation: "api".into(),
                         created_at_unix_secs: 3,
+                        divergence_state: BranchDivergenceState::Unknown,
                         pull_request: None,
                         archived: false,
                     },
@@ -698,6 +706,7 @@ mod tests {
                         fork_point_oid: "platform-root".into(),
                         head_oid_at_creation: "platform-root".into(),
                         created_at_unix_secs: 4,
+                        divergence_state: BranchDivergenceState::Unknown,
                         pull_request: None,
                         archived: false,
                     },

--- a/src/core/store/mod.rs
+++ b/src/core/store/mod.rs
@@ -14,17 +14,17 @@ pub(crate) use events::append_event;
 pub(crate) use fs::dig_paths;
 pub(crate) use mutations::{
     record_branch_adopted, record_branch_archived, record_branch_created,
-    record_branch_pull_request_tracked, record_branch_reparented,
+    record_branch_divergence_state, record_branch_pull_request_tracked, record_branch_reparented,
 };
 pub(crate) use operation::{clear_operation, load_operation, save_operation};
 pub(crate) use session::{StoreSession, open_initialized, open_or_initialize};
 pub(crate) use state::{load_state, save_state};
 pub(crate) use types::{
-    BranchAdoptedEvent, BranchArchiveReason, BranchArchivedEvent, BranchCreatedEvent, BranchNode,
-    BranchPullRequestTrackedEvent, BranchPullRequestTrackedSource, BranchReparentedEvent,
-    DigConfig, DigEvent, ParentRef, PendingAdoptOperation, PendingCleanCandidate,
-    PendingCleanCandidateKind, PendingCleanOperation, PendingCommitEntry, PendingCommitOperation,
-    PendingMergeOperation, PendingOperationKind, PendingOperationState, PendingOrphanOperation,
-    PendingReparentOperation, PendingSyncOperation, PendingSyncPhase, TrackedPullRequest,
-    now_unix_timestamp_secs,
+    BranchAdoptedEvent, BranchArchiveReason, BranchArchivedEvent, BranchCreatedEvent,
+    BranchDivergenceState, BranchNode, BranchPullRequestTrackedEvent,
+    BranchPullRequestTrackedSource, BranchReparentedEvent, DigConfig, DigEvent, ParentRef,
+    PendingAdoptOperation, PendingCleanCandidate, PendingCleanCandidateKind, PendingCleanOperation,
+    PendingCommitEntry, PendingCommitOperation, PendingMergeOperation, PendingOperationKind,
+    PendingOperationState, PendingOrphanOperation, PendingReparentOperation, PendingSyncOperation,
+    PendingSyncPhase, TrackedPullRequest, now_unix_timestamp_secs,
 };

--- a/src/core/store/mutations.rs
+++ b/src/core/store/mutations.rs
@@ -3,9 +3,10 @@ use std::io;
 use uuid::Uuid;
 
 use super::{
-    BranchAdoptedEvent, BranchArchiveReason, BranchArchivedEvent, BranchCreatedEvent, BranchNode,
-    BranchPullRequestTrackedEvent, BranchPullRequestTrackedSource, BranchReparentedEvent, DigEvent,
-    ParentRef, TrackedPullRequest, now_unix_timestamp_secs, save_state,
+    BranchAdoptedEvent, BranchArchiveReason, BranchArchivedEvent, BranchCreatedEvent,
+    BranchDivergenceState, BranchNode, BranchPullRequestTrackedEvent,
+    BranchPullRequestTrackedSource, BranchReparentedEvent, DigEvent, ParentRef, TrackedPullRequest,
+    now_unix_timestamp_secs, save_state,
 };
 use crate::core::store::append_event;
 use crate::core::store::session::StoreSession;
@@ -98,4 +99,20 @@ pub fn record_branch_pull_request_tracked(
             source,
         }),
     )
+}
+
+pub fn record_branch_divergence_state(
+    session: &mut StoreSession,
+    branch_id: Uuid,
+    divergence_state: BranchDivergenceState,
+) -> io::Result<bool> {
+    if !session
+        .state
+        .set_branch_divergence_state(branch_id, divergence_state)?
+    {
+        return Ok(false);
+    }
+
+    save_state(&session.paths, &session.state)?;
+    Ok(true)
 }

--- a/src/core/store/types.rs
+++ b/src/core/store/types.rs
@@ -117,6 +117,23 @@ impl DigState {
 
         Ok(())
     }
+
+    pub fn set_branch_divergence_state(
+        &mut self,
+        node_id: Uuid,
+        divergence_state: BranchDivergenceState,
+    ) -> io::Result<bool> {
+        let node = self.find_branch_by_id_mut(node_id).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::NotFound, "tracked branch was not found")
+        })?;
+
+        if node.divergence_state == divergence_state {
+            return Ok(false);
+        }
+
+        node.divergence_state = divergence_state;
+        Ok(true)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -300,8 +317,21 @@ pub struct BranchNode {
     pub head_oid_at_creation: String,
     pub created_at_unix_secs: u64,
     #[serde(default)]
+    pub divergence_state: BranchDivergenceState,
+    #[serde(default)]
     pub pull_request: Option<TrackedPullRequest>,
     pub archived: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum BranchDivergenceState {
+    #[default]
+    Unknown,
+    NeverDiverged {
+        aligned_head_oid: String,
+    },
+    Diverged,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -391,11 +421,11 @@ pub fn now_unix_timestamp_secs() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::{
-        BranchAdoptedEvent, BranchArchiveReason, BranchArchivedEvent, BranchNode,
-        BranchPullRequestTrackedEvent, BranchPullRequestTrackedSource, DigConfig, DigEvent,
-        DigState, ParentRef, PendingCommitOperation, PendingOperationKind, PendingOperationState,
-        PendingOrphanOperation, PendingReparentOperation, PendingSyncOperation, PendingSyncPhase,
-        TrackedPullRequest,
+        BranchAdoptedEvent, BranchArchiveReason, BranchArchivedEvent, BranchDivergenceState,
+        BranchNode, BranchPullRequestTrackedEvent, BranchPullRequestTrackedSource, DigConfig,
+        DigEvent, DigState, ParentRef, PendingCommitOperation, PendingOperationKind,
+        PendingOperationState, PendingOrphanOperation, PendingReparentOperation,
+        PendingSyncOperation, PendingSyncPhase, TrackedPullRequest,
     };
     use crate::core::restack::{RestackAction, RestackBaseTarget};
     use uuid::Uuid;
@@ -410,6 +440,7 @@ mod tests {
             fork_point_oid: "abc123".into(),
             head_oid_at_creation: "abc123".into(),
             created_at_unix_secs: 1,
+            divergence_state: BranchDivergenceState::Unknown,
             pull_request: None,
             archived: false,
         };
@@ -469,6 +500,7 @@ mod tests {
                 fork_point_oid: "abc123".into(),
                 head_oid_at_creation: "def456".into(),
                 created_at_unix_secs: 1,
+                divergence_state: BranchDivergenceState::Unknown,
                 pull_request: None,
                 archived: false,
             },
@@ -513,7 +545,32 @@ mod tests {
         )
         .unwrap();
 
+        assert_eq!(node.divergence_state, BranchDivergenceState::Unknown);
         assert_eq!(node.pull_request, None);
+    }
+
+    #[test]
+    fn serializes_branch_divergence_state() {
+        let node = BranchNode {
+            id: Uuid::nil(),
+            branch_name: "feature/api".into(),
+            parent: ParentRef::Trunk,
+            base_ref: "main".into(),
+            fork_point_oid: "abc123".into(),
+            head_oid_at_creation: "abc123".into(),
+            created_at_unix_secs: 1,
+            divergence_state: BranchDivergenceState::NeverDiverged {
+                aligned_head_oid: "abc123".into(),
+            },
+            pull_request: None,
+            archived: false,
+        };
+
+        let serialized = serde_json::to_string(&node).unwrap();
+
+        assert!(serialized.contains("\"divergence_state\""));
+        assert!(serialized.contains("\"kind\":\"never_diverged\""));
+        assert!(serialized.contains("\"aligned_head_oid\":\"abc123\""));
     }
 
     #[test]

--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -314,6 +314,7 @@ where
     let mut session = open_initialized("dig is not initialized; run 'dig init' first")?;
     workflow::ensure_ready_for_operation(&session.repo, "sync")?;
     workflow::ensure_no_pending_operation(&session.paths, "sync")?;
+    clean::reconcile_branch_divergence_state(&mut session)?;
     let remote_sync_enabled = fetch_sync_remotes(&session)?;
     let repaired_pull_requests = if remote_sync_enabled {
         repair_closed_pull_requests_for_deleted_parent_branches(&session)?
@@ -347,6 +348,7 @@ where
     F: FnMut(SyncEvent) -> io::Result<()>,
 {
     let mut session = open_initialized("dig is not initialized; run 'dig init' first")?;
+    clean::reconcile_branch_divergence_state(&mut session)?;
     let mut progress = LocalSyncProgress {
         repaired_pull_requests: Vec::new(),
         deleted_branches: payload.deleted_branches,
@@ -435,6 +437,8 @@ where
     let cleanup_mode = clean::mode_for_sync(remote_sync_enabled);
 
     loop {
+        clean::reconcile_branch_divergence_state(session)?;
+
         if let Some(step) = plan_deleted_local_branch_step(session)? {
             if let Some(outcome) = apply_deleted_local_branch_step(
                 session,
@@ -603,7 +607,7 @@ fn plan_outdated_branch_step(
             ));
         }
 
-        if clean::branch_is_integrated(&parent_branch_name, &node.branch_name)? {
+        if clean::tracked_branch_is_integrated(&node, &parent_branch_name)? {
             continue;
         }
 

--- a/src/core/tree.rs
+++ b/src/core/tree.rs
@@ -277,7 +277,7 @@ mod tests {
     };
     use crate::core::store::types::DIG_STATE_VERSION;
     use crate::core::store::types::DigState;
-    use crate::core::store::{BranchNode, ParentRef};
+    use crate::core::store::{BranchDivergenceState, BranchNode, ParentRef};
     use uuid::Uuid;
 
     #[test]
@@ -296,6 +296,7 @@ mod tests {
                     fork_point_oid: "1".into(),
                     head_oid_at_creation: "1".into(),
                     created_at_unix_secs: 1,
+                    divergence_state: BranchDivergenceState::Unknown,
                     pull_request: Some(crate::core::store::TrackedPullRequest { number: 101 }),
                     archived: false,
                 },
@@ -307,6 +308,7 @@ mod tests {
                     fork_point_oid: "2".into(),
                     head_oid_at_creation: "2".into(),
                     created_at_unix_secs: 2,
+                    divergence_state: BranchDivergenceState::Unknown,
                     pull_request: Some(crate::core::store::TrackedPullRequest { number: 102 }),
                     archived: false,
                 },
@@ -318,6 +320,7 @@ mod tests {
                     fork_point_oid: "3".into(),
                     head_oid_at_creation: "3".into(),
                     created_at_unix_secs: 3,
+                    divergence_state: BranchDivergenceState::Unknown,
                     pull_request: None,
                     archived: false,
                 },

--- a/tests/commit.rs
+++ b/tests/commit.rs
@@ -4,7 +4,8 @@ use std::fs;
 
 use support::{
     active_rebase_head_name, append_to_file, commit_file, dig, dig_ok, git_ok, git_stdout,
-    initialize_main_repo, load_operation_json, strip_ansi, with_temp_repo, write_file,
+    initialize_main_repo, load_operation_json, load_state_json, strip_ansi, with_temp_repo,
+    write_file,
 };
 
 #[test]
@@ -25,7 +26,6 @@ fn restacks_tracked_descendants_after_commit_and_preserves_store_files() {
         );
         git_ok(repo, &["checkout", "feat/auth"]);
 
-        let state_before = fs::read_to_string(repo.join(".git/dig/state.json")).unwrap();
         let events_before = fs::read_to_string(repo.join(".git/dig/events.ndjson")).unwrap();
 
         append_to_file(repo, "auth.txt", "follow-up\n");
@@ -50,9 +50,16 @@ fn restacks_tracked_descendants_after_commit_and_preserves_store_files() {
             ),
             git_stdout(repo, &["rev-parse", "feat/auth-api"])
         );
+        let state = load_state_json(repo);
         assert_eq!(
-            fs::read_to_string(repo.join(".git/dig/state.json")).unwrap(),
-            state_before
+            state["nodes"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|node| node["branch_name"].as_str() == Some("feat/auth"))
+                .unwrap()["divergence_state"]["kind"]
+                .as_str(),
+            Some("diverged")
         );
         assert_eq!(
             fs::read_to_string(repo.join(".git/dig/events.ndjson")).unwrap(),
@@ -72,7 +79,6 @@ fn restacks_child_after_amend_using_old_head_oid() {
         commit_file(repo, "ui.txt", "ui\n", "feat: auth ui");
         git_ok(repo, &["checkout", "feat/auth"]);
 
-        let state_before = fs::read_to_string(repo.join(".git/dig/state.json")).unwrap();
         let events_before = fs::read_to_string(repo.join(".git/dig/events.ndjson")).unwrap();
         let old_head = git_stdout(repo, &["rev-parse", "feat/auth"]);
 
@@ -91,9 +97,16 @@ fn restacks_child_after_amend_using_old_head_oid() {
             new_head
         );
         assert_eq!(git_stdout(repo, &["branch", "--show-current"]), "feat/auth");
+        let state = load_state_json(repo);
         assert_eq!(
-            fs::read_to_string(repo.join(".git/dig/state.json")).unwrap(),
-            state_before
+            state["nodes"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|node| node["branch_name"].as_str() == Some("feat/auth"))
+                .unwrap()["divergence_state"]["kind"]
+                .as_str(),
+            Some("diverged")
         );
         assert_eq!(
             fs::read_to_string(repo.join(".git/dig/events.ndjson")).unwrap(),
@@ -125,7 +138,6 @@ fn leaves_rebase_open_on_conflicting_child_after_commit() {
         );
         git_ok(repo, &["checkout", "feat/auth"]);
 
-        let state_before = fs::read_to_string(repo.join(".git/dig/state.json")).unwrap();
         let events_before = fs::read_to_string(repo.join(".git/dig/events.ndjson")).unwrap();
 
         write_file(repo, "shared.txt", "parent\n");
@@ -149,9 +161,16 @@ fn leaves_rebase_open_on_conflicting_child_after_commit() {
             git_stdout(repo, &["log", "-1", "--format=%s", "feat/auth"]),
             "feat: parent follow-up"
         );
+        let state = load_state_json(repo);
         assert_eq!(
-            fs::read_to_string(repo.join(".git/dig/state.json")).unwrap(),
-            state_before
+            state["nodes"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|node| node["branch_name"].as_str() == Some("feat/auth"))
+                .unwrap()["divergence_state"]["kind"]
+                .as_str(),
+            Some("diverged")
         );
         assert_eq!(
             fs::read_to_string(repo.join(".git/dig/events.ndjson")).unwrap(),

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -178,6 +178,96 @@ fn sync_reports_noop_when_local_stacks_are_already_in_sync() {
 }
 
 #[test]
+fn sync_does_not_prompt_to_clean_fresh_branch_without_commits() {
+    with_temp_repo("dig-sync-cli", |repo| {
+        initialize_main_repo(repo);
+        dig_ok(repo, &["init"]);
+        dig_ok(repo, &["branch", "feat/auth"]);
+
+        let output = dig_ok(repo, &["sync"]);
+        let stdout = strip_ansi(&String::from_utf8(output.stdout).unwrap());
+
+        assert_eq!(stdout.trim_end(), "Local stacks are already in sync.");
+        assert!(!stdout.contains("Merged branches ready to clean:"));
+        assert!(!stdout.contains("Delete 1 merged branch? [y/N]"));
+    });
+}
+
+#[test]
+fn sync_does_not_prompt_to_clean_fresh_child_branch_without_commits() {
+    with_temp_repo("dig-sync-cli", |repo| {
+        initialize_main_repo(repo);
+        dig_ok(repo, &["init"]);
+        dig_ok(repo, &["branch", "feat/auth"]);
+        commit_file(repo, "auth.txt", "auth\n", "feat: auth");
+        dig_ok(repo, &["branch", "feat/auth-ui"]);
+
+        let output = dig_ok(repo, &["sync"]);
+        let stdout = strip_ansi(&String::from_utf8(output.stdout).unwrap());
+
+        assert_eq!(stdout.trim_end(), "Local stacks are already in sync.");
+        assert!(!stdout.contains("Merged branches ready to clean:"));
+        assert!(!stdout.contains("Delete 1 merged branch? [y/N]"));
+    });
+}
+
+#[test]
+fn sync_restacks_fresh_branch_after_trunk_advances_without_prompting_cleanup() {
+    with_temp_repo("dig-sync-cli", |repo| {
+        initialize_main_repo(repo);
+        dig_ok(repo, &["init"]);
+        dig_ok(repo, &["branch", "feat/auth"]);
+        git_ok(repo, &["checkout", "main"]);
+        commit_file(repo, "README.md", "root\nmain\n", "feat: trunk follow-up");
+        git_ok(repo, &["checkout", "feat/auth"]);
+
+        let output = dig_ok(repo, &["sync"]);
+        let stdout = strip_ansi(&String::from_utf8(output.stdout).unwrap());
+        let state = load_state_json(repo);
+        let auth = find_node(&state, "feat/auth").unwrap();
+
+        assert!(stdout.contains("Restacked:"));
+        assert!(stdout.contains("- feat/auth onto main"));
+        assert!(!stdout.contains("Merged branches ready to clean:"));
+        assert!(!stdout.contains("Delete 1 merged branch? [y/N]"));
+        assert_eq!(
+            git_stdout(repo, &["merge-base", "main", "feat/auth"]),
+            git_stdout(repo, &["rev-parse", "main"])
+        );
+        assert_eq!(
+            auth["divergence_state"]["kind"].as_str(),
+            Some("never_diverged")
+        );
+        assert_eq!(
+            auth["divergence_state"]["aligned_head_oid"].as_str(),
+            Some(git_stdout(repo, &["rev-parse", "feat/auth"]).as_str())
+        );
+    });
+}
+
+#[test]
+fn sync_cleans_fast_forward_merged_branch_after_manual_git_commit() {
+    with_temp_repo("dig-sync-cli", |repo| {
+        initialize_main_repo(repo);
+        dig_ok(repo, &["init"]);
+        dig_ok(repo, &["branch", "feat/auth"]);
+        commit_file(repo, "auth.txt", "auth\n", "feat: auth");
+        git_ok(repo, &["checkout", "main"]);
+        git_ok(repo, &["merge", "--ff-only", "feat/auth"]);
+
+        let output = dig_with_input(repo, &["sync"], "y\n");
+        let stdout = strip_ansi(&String::from_utf8(output.stdout).unwrap());
+
+        assert!(stdout.contains("Merged branches ready to clean:"));
+        assert!(stdout.contains("- feat/auth merged into main"));
+        assert!(stdout.contains("Delete 1 merged branch? [y/N]"));
+        assert!(stdout.contains("Deleted:"));
+        assert!(stdout.contains("- feat/auth"));
+        assert!(!git_stdout(repo, &["branch", "--list", "feat/auth"]).contains("feat/auth"));
+    });
+}
+
+#[test]
 fn sync_cleans_branch_merged_by_tracked_pull_request_number_without_rebasing() {
     with_temp_repo("dig-sync-cli", |repo| {
         initialize_main_repo(repo);


### PR DESCRIPTION
This pull request introduces a new mechanism for tracking and reconciling the divergence state of branches, improving how the system determines if a branch can be cleaned up. The changes ensure that only branches which have diverged (i.e., have unique commits relative to their parent) are considered for cleaning, and they provide robust handling for legacy and edge cases. The update also adds thorough tests for these scenarios.

**Branch Divergence State Tracking and Reconciliation:**

* Introduced the `BranchDivergenceState` field to `BranchNode` creation and update flows in `adopt.rs` and `branch.rs`, ensuring that new and existing branches have their divergence state correctly set and maintained. [[1]](diffhunk://#diff-14671c55f6646672e0ce22b4046d42c38c82081091d73de573d81c6825e74661L10-R12) [[2]](diffhunk://#diff-14671c55f6646672e0ce22b4046d42c38c82081091d73de573d81c6825e74661L181-R191) [[3]](diffhunk://#diff-14671c55f6646672e0ce22b4046d42c38c82081091d73de573d81c6825e74661L264-R281) [[4]](diffhunk://#diff-b829e36ba9c7a3c6712d8549372410b0f3643cde8a926ba927219fd7901dccf5L11-R12) [[5]](diffhunk://#diff-b829e36ba9c7a3c6712d8549372410b0f3643cde8a926ba927219fd7901dccf5L80-R84) [[6]](diffhunk://#diff-b829e36ba9c7a3c6712d8549372410b0f3643cde8a926ba927219fd7901dccf5L152-R155) [[7]](diffhunk://#diff-b829e36ba9c7a3c6712d8549372410b0f3643cde8a926ba927219fd7901dccf5R192)
* Added the `reconcile_branch_divergence_state` function in `clean/plan.rs`, which scans all branches and updates their divergence state based on their commit history and reflog, and integrated this reconciliation step into the clean planning process. [[1]](diffhunk://#diff-50efe08386d6ae0a5af8268d0485999ffadf2cfe4ae70f648a8570f7cc53a799R39-R73) [[2]](diffhunk://#diff-50efe08386d6ae0a5af8268d0485999ffadf2cfe4ae70f648a8570f7cc53a799L79-R115)
* Implemented logic to determine divergence by checking for unique commits and inspecting the reflog for evidence of divergence, providing robust handling for branches with missing or legacy divergence state.

**Clean Operation Logic Improvements:**

* Updated the clean planning and evaluation logic to block cleaning of branches that have never diverged from their parent, and to only allow cleaning for branches in the `Diverged` state. [[1]](diffhunk://#diff-50efe08386d6ae0a5af8268d0485999ffadf2cfe4ae70f648a8570f7cc53a799R310-R318) [[2]](diffhunk://#diff-50efe08386d6ae0a5af8268d0485999ffadf2cfe4ae70f648a8570f7cc53a799L402-R460)
* Renamed and refactored integration checks to use the new divergence state, ensuring that only eligible branches are considered integrated and cleanable. [[1]](diffhunk://#diff-773e14cf2cad91d15d536610adf19d1c5813681e83e3b83a0413a21aff3b2ceaL7-R8) [[2]](diffhunk://#diff-50efe08386d6ae0a5af8268d0485999ffadf2cfe4ae70f648a8570f7cc53a799L402-R460)

**Testing and Edge Case Handling:**

* Added comprehensive tests covering fresh branches, rebased branches, and legacy branches with unknown divergence state, verifying that only appropriate branches are marked as cleanable and that divergence state is reconciled as expected. [[1]](diffhunk://#diff-20bed3fe05ac58585b704035206a1b430d38a4f915b5cd05d4cf617b688ea7f6R1) [[2]](diffhunk://#diff-20bed3fe05ac58585b704035206a1b430d38a4f915b5cd05d4cf617b688ea7f6L11-R13) [[3]](diffhunk://#diff-20bed3fe05ac58585b704035206a1b430d38a4f915b5cd05d4cf617b688ea7f6R126-R235)

**Supporting Changes:**

* Added a new `reflog_subjects` function in `git.rs` to fetch reflog subjects for divergence detection.
* Ensured that after a commit, the divergence state of the branch is updated to `Diverged`. [[1]](diffhunk://#diff-bb627db6e7dad045d9ff507de7d44fd995f168fa3b2e5118792ee6747080fe77L7-R9) [[2]](diffhunk://#diff-bb627db6e7dad045d9ff507de7d44fd995f168fa3b2e5118792ee6747080fe77R315)
* Updated imports and test fixtures to include `BranchDivergenceState` where necessary.

These changes collectively improve the reliability and accuracy of the branch cleaning process by making divergence state a first-class concept in the system.