### PR TITLE
feat(sync): show animated progress status in tree view when syncing

### DIFF
--- a/src/cli/clean/mod.rs
+++ b/src/cli/clean/mod.rs
@@ -1,4 +1,4 @@
-mod render;
+pub(crate) mod render;
 
 use std::io;
 use std::io::IsTerminal;

--- a/src/cli/clean/render.rs
+++ b/src/cli/clean/render.rs
@@ -1,4 +1,5 @@
 use crate::core::clean::{CleanCandidate, CleanEvent, CleanPlan, CleanTreeNode};
+use crate::core::restack::RestackPreview;
 
 pub use super::super::operation::AnimationTerminal;
 use super::super::operation::{BranchStatus, OperationSection, VisualNode, render_sections};
@@ -71,6 +72,38 @@ impl CleanAnimation {
         render_sections(&self.sections, true)
     }
 
+    pub fn prime_resume(
+        &mut self,
+        restacked_branches: &[RestackPreview],
+        deleted_branches: &[String],
+        untracked_branches: &[String],
+        active_branch_name: &str,
+    ) {
+        self.clear_in_flight();
+
+        for branch in restacked_branches {
+            if let Some(node) = self.find_node_mut(&branch.branch_name) {
+                node.status = BranchStatus::Succeeded;
+            }
+        }
+
+        for branch_name in deleted_branches {
+            if let Some(node) = self.find_node_mut(branch_name) {
+                node.status = BranchStatus::Deleted;
+            }
+        }
+
+        for branch_name in untracked_branches {
+            if let Some(node) = self.find_node_mut(branch_name) {
+                node.status = BranchStatus::Archived;
+            }
+        }
+
+        if let Some(node) = self.find_node_mut(active_branch_name) {
+            node.status = BranchStatus::start_in_flight();
+        }
+    }
+
     fn find_node_mut(&mut self, branch_name: &str) -> Option<&mut VisualNode> {
         for section in &mut self.sections {
             if let Some(node) = section.root.find_mut(branch_name) {
@@ -79,6 +112,12 @@ impl CleanAnimation {
         }
 
         None
+    }
+
+    fn clear_in_flight(&mut self) {
+        for section in &mut self.sections {
+            clear_in_flight(&mut section.root);
+        }
     }
 }
 
@@ -95,6 +134,16 @@ fn visual_node_from_tree(tree: &CleanTreeNode) -> VisualNode {
         tree.branch_name.clone(),
         tree.children.iter().map(visual_node_from_tree).collect(),
     )
+}
+
+fn clear_in_flight(node: &mut VisualNode) {
+    if matches!(node.status, BranchStatus::InFlight { .. }) {
+        node.status = BranchStatus::Pending;
+    }
+
+    for child in &mut node.children {
+        clear_in_flight(child);
+    }
 }
 
 #[cfg(test)]
@@ -201,6 +250,60 @@ mod tests {
         assert_eq!(
             animation.render_final(),
             concat!("main\n", "└── feat/users")
+        );
+    }
+
+    #[test]
+    fn primes_resumed_cleanup_with_completed_and_active_branches() {
+        let mut animation = CleanAnimation::new(&CleanPlan {
+            trunk_branch: "main".into(),
+            current_branch: "main".into(),
+            requested_branch_name: None,
+            candidates: vec![CleanCandidate {
+                node_id: Uuid::new_v4(),
+                branch_name: "feat/auth".into(),
+                parent_branch_name: "main".into(),
+                reason: CleanReason::IntegratedIntoParent {
+                    parent_base: RestackBaseTarget::local("main"),
+                },
+                tree: CleanTreeNode {
+                    branch_name: "feat/auth".into(),
+                    children: vec![
+                        CleanTreeNode {
+                            branch_name: "feat/auth-api".into(),
+                            children: vec![],
+                        },
+                        CleanTreeNode {
+                            branch_name: "feat/auth-ui".into(),
+                            children: vec![],
+                        },
+                    ],
+                },
+                restack_plan: vec![],
+                depth: 0,
+            }],
+            blocked: vec![],
+        });
+
+        animation.prime_resume(
+            &[crate::core::restack::RestackPreview {
+                branch_name: "feat/auth-api".into(),
+                onto_branch: "feat/auth".into(),
+                parent_changed: false,
+            }],
+            &[],
+            &[],
+            "feat/auth-ui",
+        );
+
+        assert_eq!(
+            animation.render_active(),
+            concat!(
+                "main\n",
+                "└── feat/auth\n",
+                "    ├── \u{1b}[32m✓\u{1b}[0m feat/auth-api\n",
+                "    └── \u{1b}[34m|\u{1b}[0m feat/auth-ui"
+            )
         );
     }
 }

--- a/src/cli/sync/mod.rs
+++ b/src/cli/sync/mod.rs
@@ -1,13 +1,17 @@
+mod render;
+
 use std::io;
+use std::io::IsTerminal;
 
 use clap::Args;
 
 use crate::core::clean;
 use crate::core::merge;
 use crate::core::sync::{
-    self, RemotePushActionKind, RemotePushOutcome, SyncCompletion, SyncOptions,
+    self, RemotePushActionKind, RemotePushOutcome, SyncCompletion, SyncEvent, SyncOptions,
+    SyncStage,
 };
-use crate::core::tree;
+use crate::core::tree::{self, TreeOptions};
 
 use super::CommandOutcome;
 use super::common;
@@ -20,7 +24,22 @@ pub struct SyncArgs {
 }
 
 pub fn execute(args: SyncArgs) -> io::Result<CommandOutcome> {
-    let outcome = sync::run(&args.clone().into())?;
+    let animate = io::stdout().is_terminal();
+    let mut animation = SyncAnimationSession::default();
+    let outcome = if animate {
+        sync::run_with_reporter(&args.clone().into(), &mut |event| animation.apply(event))?
+    } else {
+        sync::run(&args.clone().into())?
+    };
+
+    if animate {
+        if outcome.status.success() {
+            animation.finish_success()?;
+        } else {
+            animation.finish_failure()?;
+        }
+    }
+
     let mut final_status = outcome.status;
 
     if let Some(completion) = &outcome.completion {
@@ -138,7 +157,13 @@ pub fn execute(args: SyncArgs) -> io::Result<CommandOutcome> {
                     } else {
                         println!();
 
-                        let clean_outcome = clean::apply(&full_outcome.cleanup_plan)?;
+                        let clean_outcome = if animate {
+                            println!("Finished local sync. Moving on to cleanup.");
+                            println!();
+                            execute_cleanup_with_animation(&full_outcome.cleanup_plan)?
+                        } else {
+                            clean::apply(&full_outcome.cleanup_plan)?
+                        };
                         final_status = clean_outcome.status;
 
                         if clean_outcome.status.success() {
@@ -244,9 +269,165 @@ pub fn execute(args: SyncArgs) -> io::Result<CommandOutcome> {
         }
     }
 
+    if animate && final_status.success() {
+        let tree_outcome = tree::run(&TreeOptions::default())?;
+        println!();
+        println!("{}", render::render_completed_tree(&tree_outcome.view));
+    }
+
     Ok(CommandOutcome {
         status: final_status,
     })
+}
+
+#[derive(Default)]
+struct SyncAnimationSession {
+    terminal: Option<render::AnimationTerminal>,
+    stage: Option<ActiveSyncStage>,
+}
+
+enum ActiveSyncStage {
+    Local(render::SyncAnimation),
+    Cleanup(super::clean::render::CleanAnimation),
+}
+
+impl SyncAnimationSession {
+    fn apply(&mut self, event: SyncEvent) -> io::Result<()> {
+        match event {
+            SyncEvent::StageStarted(SyncStage::LocalSync { .. }) => {
+                if let Some(ActiveSyncStage::Local(animation)) = self.stage.as_mut() {
+                    if animation.apply_event(&event) {
+                        self.render_active()?;
+                    }
+
+                    return Ok(());
+                }
+
+                let outcome = tree::run(&TreeOptions::default())?;
+                let mut animation = render::SyncAnimation::new(&outcome.view);
+                animation.apply_event(&event);
+                let mut terminal = render::AnimationTerminal::start()?;
+                terminal.render(&animation.render_active())?;
+                self.terminal = Some(terminal);
+                self.stage = Some(ActiveSyncStage::Local(animation));
+                Ok(())
+            }
+            SyncEvent::StageStarted(SyncStage::CleanupResume {
+                plan,
+                active_branch_name,
+                untracked_branches,
+                deleted_branches,
+                restacked_branches,
+            }) => {
+                let mut animation = super::clean::render::CleanAnimation::new(&plan);
+                animation.prime_resume(
+                    &restacked_branches,
+                    &deleted_branches,
+                    &untracked_branches,
+                    &active_branch_name,
+                );
+                let mut terminal = render::AnimationTerminal::start()?;
+                terminal.render(&animation.render_active())?;
+                self.terminal = Some(terminal);
+                self.stage = Some(ActiveSyncStage::Cleanup(animation));
+                Ok(())
+            }
+            SyncEvent::Cleanup(clean_event) => {
+                let Some(ActiveSyncStage::Cleanup(animation)) = self.stage.as_mut() else {
+                    return Ok(());
+                };
+
+                if animation.apply_event(&clean_event) {
+                    self.render_active()?;
+                }
+
+                Ok(())
+            }
+            _ => {
+                let Some(ActiveSyncStage::Local(animation)) = self.stage.as_mut() else {
+                    return Ok(());
+                };
+
+                if animation.apply_event(&event) {
+                    self.render_active()?;
+                }
+
+                Ok(())
+            }
+        }
+    }
+
+    fn finish_success(&mut self) -> io::Result<()> {
+        let Some(mut terminal) = self.terminal.take() else {
+            return Ok(());
+        };
+        let Some(stage) = self.stage.take() else {
+            return Ok(());
+        };
+
+        let frame = match stage {
+            ActiveSyncStage::Local(animation) => animation.render_final(),
+            ActiveSyncStage::Cleanup(animation) => animation.render_final(),
+        };
+        terminal.finish(&frame)
+    }
+
+    fn finish_failure(&mut self) -> io::Result<()> {
+        let Some(mut terminal) = self.terminal.take() else {
+            return Ok(());
+        };
+        let Some(stage) = self.stage.take() else {
+            return Ok(());
+        };
+
+        let frame = match stage {
+            ActiveSyncStage::Local(animation) => animation.render_active(),
+            ActiveSyncStage::Cleanup(animation) => animation.render_active(),
+        };
+        terminal.finish(&frame)
+    }
+
+    fn render_active(&mut self) -> io::Result<()> {
+        let Some(terminal) = self.terminal.as_mut() else {
+            return Ok(());
+        };
+        let Some(stage) = self.stage.as_ref() else {
+            return Ok(());
+        };
+
+        let frame = match stage {
+            ActiveSyncStage::Local(animation) => animation.render_active(),
+            ActiveSyncStage::Cleanup(animation) => animation.render_active(),
+        };
+        terminal.render(&frame)
+    }
+}
+
+fn execute_cleanup_with_animation(plan: &clean::CleanPlan) -> io::Result<clean::CleanApplyOutcome> {
+    let mut animation = super::clean::render::CleanAnimation::new(plan);
+    let mut terminal = render::AnimationTerminal::start()?;
+    terminal.render(&animation.render_active())?;
+
+    let outcome = clean::apply_with_reporter(plan, &mut |event| {
+        if animation.apply_event(&event) {
+            terminal.render(&animation.render_active())?;
+        }
+
+        Ok(())
+    })?;
+
+    if outcome.status.success() {
+        terminal.finish(&animation.render_final())?;
+    } else {
+        terminal.finish(&animation.render_active())?;
+        if outcome.paused {
+            common::print_restack_pause_guidance(outcome.failure_output.as_deref());
+        } else {
+            common::print_trimmed_stderr(outcome.failure_output.as_deref());
+        }
+    }
+
+    Ok(outcome)
 }
 
 impl From<SyncArgs> for SyncOptions {

--- a/src/cli/sync/render.rs
+++ b/src/cli/sync/render.rs
@@ -1,0 +1,443 @@
+use crate::cli::common;
+use crate::core::restack::RestackPreview;
+use crate::core::sync::{SyncEvent, SyncStage};
+use crate::core::tree::{TreeNode, TreeView};
+use crate::ui::markers;
+use crate::ui::palette::Accent;
+
+pub use super::super::operation::AnimationTerminal;
+
+pub struct SyncAnimation {
+    root_label: Option<String>,
+    roots: Vec<VisualTreeNode>,
+}
+
+impl SyncAnimation {
+    pub fn new(view: &TreeView) -> Self {
+        Self {
+            root_label: view
+                .root_label
+                .as_ref()
+                .map(|label| label.branch_name.clone()),
+            roots: view.roots.iter().map(visual_node_from_tree).collect(),
+        }
+    }
+
+    pub fn apply_event(&mut self, event: &SyncEvent) -> bool {
+        match event {
+            SyncEvent::StageStarted(SyncStage::LocalSync {
+                active_branch_name,
+                deleted_branches,
+                restacked_branches,
+                ..
+            }) => {
+                self.prime_resume(restacked_branches, deleted_branches, active_branch_name);
+                true
+            }
+            SyncEvent::BranchArchived { branch_name } => self
+                .find_node_mut(branch_name)
+                .map(|node| node.status = SyncBranchStatus::Archived)
+                .is_some(),
+            SyncEvent::RestackStarted { branch_name, .. } => {
+                self.clear_in_flight();
+                self.find_node_mut(branch_name)
+                    .map(|node| node.status = SyncBranchStatus::start_in_flight())
+                    .is_some()
+            }
+            SyncEvent::RestackProgress {
+                branch_name,
+                current_commit,
+                total_commits,
+                ..
+            } => self
+                .find_node_mut(branch_name)
+                .map(|node| {
+                    node.status = node
+                        .status
+                        .advance_progress(*current_commit, *total_commits)
+                })
+                .is_some(),
+            SyncEvent::RestackCompleted { branch_name, .. } => self
+                .find_node_mut(branch_name)
+                .map(|node| node.status = SyncBranchStatus::Succeeded)
+                .is_some(),
+            SyncEvent::StageStarted(SyncStage::CleanupResume { .. }) | SyncEvent::Cleanup(_) => {
+                false
+            }
+        }
+    }
+
+    pub fn render_active(&self) -> String {
+        common::render_tree(
+            self.root_label.clone(),
+            &self.roots,
+            &format_branch_label,
+            &|node| node.children.as_slice(),
+        )
+    }
+
+    pub fn render_final(&self) -> String {
+        let roots = prune_final_nodes(&self.roots);
+
+        common::render_tree(
+            self.root_label.clone(),
+            &roots,
+            &format_branch_label,
+            &|node| node.children.as_slice(),
+        )
+    }
+
+    fn prime_resume(
+        &mut self,
+        restacked_branches: &[RestackPreview],
+        deleted_branches: &[String],
+        active_branch_name: &str,
+    ) {
+        self.clear_in_flight();
+
+        for branch in restacked_branches {
+            if let Some(node) = self.find_node_mut(&branch.branch_name) {
+                node.status = SyncBranchStatus::Succeeded;
+            }
+        }
+
+        for branch_name in deleted_branches {
+            if let Some(node) = self.find_node_mut(branch_name) {
+                node.status = SyncBranchStatus::Archived;
+            }
+        }
+
+        if let Some(node) = self.find_node_mut(active_branch_name) {
+            node.status = SyncBranchStatus::start_in_flight();
+        }
+    }
+
+    fn find_node_mut(&mut self, branch_name: &str) -> Option<&mut VisualTreeNode> {
+        for root in &mut self.roots {
+            if let Some(node) = root.find_mut(branch_name) {
+                return Some(node);
+            }
+        }
+
+        None
+    }
+
+    fn clear_in_flight(&mut self) {
+        for root in &mut self.roots {
+            clear_in_flight(root);
+        }
+    }
+}
+
+pub fn render_completed_tree(view: &TreeView) -> String {
+    common::render_tree(
+        view.root_label
+            .as_ref()
+            .map(|label| format_completed_label(&label.branch_name, label.pull_request_number)),
+        &view.roots,
+        &format_completed_tree_node_label,
+        &|node| node.children.as_slice(),
+    )
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct VisualTreeNode {
+    branch_name: String,
+    pull_request_number: Option<u64>,
+    status: SyncBranchStatus,
+    children: Vec<VisualTreeNode>,
+}
+
+impl VisualTreeNode {
+    fn find_mut(&mut self, branch_name: &str) -> Option<&mut VisualTreeNode> {
+        if self.branch_name == branch_name {
+            return Some(self);
+        }
+
+        for child in &mut self.children {
+            if let Some(found) = child.find_mut(branch_name) {
+                return Some(found);
+            }
+        }
+
+        None
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SyncBranchStatus {
+    Pending,
+    InFlight {
+        frame_index: usize,
+        current_commit: Option<usize>,
+        total_commits: Option<usize>,
+    },
+    Succeeded,
+    Archived,
+}
+
+impl SyncBranchStatus {
+    fn start_in_flight() -> Self {
+        Self::InFlight {
+            frame_index: 0,
+            current_commit: None,
+            total_commits: None,
+        }
+    }
+
+    fn advance_progress(&self, current_commit: usize, total_commits: usize) -> Self {
+        let frame_index = match self {
+            Self::InFlight { frame_index, .. } => {
+                (frame_index + 1) % markers::THROBBER_FRAMES.len()
+            }
+            _ => 0,
+        };
+
+        Self::InFlight {
+            frame_index,
+            current_commit: Some(current_commit),
+            total_commits: Some(total_commits),
+        }
+    }
+}
+
+fn visual_node_from_tree(node: &TreeNode) -> VisualTreeNode {
+    VisualTreeNode {
+        branch_name: node.branch_name.clone(),
+        pull_request_number: node.pull_request_number,
+        status: SyncBranchStatus::Pending,
+        children: node.children.iter().map(visual_node_from_tree).collect(),
+    }
+}
+
+fn clear_in_flight(node: &mut VisualTreeNode) {
+    if matches!(node.status, SyncBranchStatus::InFlight { .. }) {
+        node.status = SyncBranchStatus::Pending;
+    }
+
+    for child in &mut node.children {
+        clear_in_flight(child);
+    }
+}
+
+fn prune_final_nodes(nodes: &[VisualTreeNode]) -> Vec<VisualTreeNode> {
+    let mut pruned = Vec::new();
+
+    for node in nodes {
+        let children = prune_final_nodes(&node.children);
+        if matches!(node.status, SyncBranchStatus::Archived) {
+            pruned.extend(children);
+            continue;
+        }
+
+        pruned.push(VisualTreeNode {
+            branch_name: node.branch_name.clone(),
+            pull_request_number: node.pull_request_number,
+            status: node.status.clone(),
+            children,
+        });
+    }
+
+    pruned
+}
+
+fn format_branch_text(branch_name: &str, pull_request_number: Option<u64>) -> String {
+    match pull_request_number {
+        Some(number) => format!("{branch_name} (#{number})"),
+        None => branch_name.to_string(),
+    }
+}
+
+fn format_completed_label(branch_name: &str, pull_request_number: Option<u64>) -> String {
+    let label = format_branch_text(branch_name, pull_request_number);
+    format!(
+        "{} {}",
+        Accent::Success.paint_ansi(markers::SUCCESS),
+        Accent::Success.paint_ansi(&label)
+    )
+}
+
+fn format_completed_tree_node_label(node: &TreeNode) -> String {
+    format_completed_label(&node.branch_name, node.pull_request_number)
+}
+
+fn format_branch_label(node: &VisualTreeNode) -> String {
+    let label = format_branch_text(&node.branch_name, node.pull_request_number);
+
+    match &node.status {
+        SyncBranchStatus::Pending => label,
+        SyncBranchStatus::InFlight {
+            frame_index,
+            current_commit,
+            total_commits,
+        } => {
+            let marker = Accent::SyncInFlight.paint_ansi(
+                markers::THROBBER_FRAMES[*frame_index % markers::THROBBER_FRAMES.len()],
+            );
+            let progress = match (current_commit, total_commits) {
+                (Some(current), Some(total)) => format!(" [{current}/{total}]"),
+                _ => String::new(),
+            };
+
+            format!(
+                "{marker} {}{progress}",
+                Accent::SyncInFlight.paint_ansi(&label)
+            )
+        }
+        SyncBranchStatus::Succeeded => {
+            format!(
+                "{} {}",
+                Accent::Success.paint_ansi(markers::SUCCESS),
+                Accent::Success.paint_ansi(&label)
+            )
+        }
+        SyncBranchStatus::Archived => {
+            format!(
+                "{} {}",
+                Accent::TagRef.paint_ansi(markers::ARCHIVED),
+                Accent::TagRef.paint_struck_ansi(&label)
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SyncAnimation, render_completed_tree};
+    use crate::core::restack::RestackPreview;
+    use crate::core::store::PendingSyncPhase;
+    use crate::core::sync::{SyncEvent, SyncStage};
+    use crate::core::tree::{TreeLabel, TreeNode, TreeView};
+
+    fn sample_view() -> TreeView {
+        TreeView {
+            root_label: Some(TreeLabel {
+                branch_name: "main".into(),
+                is_current: false,
+                pull_request_number: None,
+            }),
+            roots: vec![TreeNode {
+                branch_name: "feat/auth".into(),
+                is_current: false,
+                pull_request_number: Some(42),
+                children: vec![
+                    TreeNode {
+                        branch_name: "feat/auth-api".into(),
+                        is_current: false,
+                        pull_request_number: None,
+                        children: vec![TreeNode {
+                            branch_name: "feat/auth-api-tests".into(),
+                            is_current: false,
+                            pull_request_number: None,
+                            children: vec![],
+                        }],
+                    },
+                    TreeNode {
+                        branch_name: "feat/auth-ui".into(),
+                        is_current: false,
+                        pull_request_number: None,
+                        children: vec![],
+                    },
+                ],
+            }],
+        }
+    }
+
+    #[test]
+    fn renders_pending_tree_without_status_markers() {
+        let animation = SyncAnimation::new(&sample_view());
+
+        assert_eq!(
+            animation.render_active(),
+            concat!(
+                "main\n",
+                "└── feat/auth (#42)\n",
+                "    ├── feat/auth-api\n",
+                "    │   └── feat/auth-api-tests\n",
+                "    └── feat/auth-ui"
+            )
+        );
+    }
+
+    #[test]
+    fn renders_completed_tree_with_all_green_checkmarks() {
+        assert_eq!(
+            render_completed_tree(&sample_view()),
+            concat!(
+                "\u{1b}[32m✓\u{1b}[0m \u{1b}[32mmain\u{1b}[0m\n",
+                "└── \u{1b}[32m✓\u{1b}[0m \u{1b}[32mfeat/auth (#42)\u{1b}[0m\n",
+                "    ├── \u{1b}[32m✓\u{1b}[0m \u{1b}[32mfeat/auth-api\u{1b}[0m\n",
+                "    │   └── \u{1b}[32m✓\u{1b}[0m \u{1b}[32mfeat/auth-api-tests\u{1b}[0m\n",
+                "    └── \u{1b}[32m✓\u{1b}[0m \u{1b}[32mfeat/auth-ui\u{1b}[0m"
+            )
+        );
+    }
+
+    #[test]
+    fn highlights_active_branch_in_orange() {
+        let mut animation = SyncAnimation::new(&sample_view());
+
+        animation.apply_event(&SyncEvent::StageStarted(SyncStage::LocalSync {
+            phase: PendingSyncPhase::RestackOutdatedLocalStacks,
+            step_branch_name: "feat/auth".into(),
+            active_branch_name: "feat/auth-api".into(),
+            deleted_branches: Vec::new(),
+            restacked_branches: Vec::new(),
+        }));
+
+        assert_eq!(
+            animation.render_active(),
+            concat!(
+                "main\n",
+                "└── feat/auth (#42)\n",
+                "    ├── \u{1b}[38;5;208m|\u{1b}[0m \u{1b}[38;5;208mfeat/auth-api\u{1b}[0m\n",
+                "    │   └── feat/auth-api-tests\n",
+                "    └── feat/auth-ui"
+            )
+        );
+    }
+
+    #[test]
+    fn keeps_completed_branches_green_and_prunes_archived_nodes_from_final_view() {
+        let mut animation = SyncAnimation::new(&sample_view());
+
+        animation.apply_event(&SyncEvent::StageStarted(SyncStage::LocalSync {
+            phase: PendingSyncPhase::ReconcileDeletedLocalBranches,
+            step_branch_name: "feat/auth-api".into(),
+            active_branch_name: "feat/auth-api-tests".into(),
+            deleted_branches: Vec::new(),
+            restacked_branches: vec![RestackPreview {
+                branch_name: "feat/auth-ui".into(),
+                onto_branch: "feat/auth".into(),
+                parent_changed: false,
+            }],
+        }));
+        animation.apply_event(&SyncEvent::BranchArchived {
+            branch_name: "feat/auth-api".into(),
+        });
+        animation.apply_event(&SyncEvent::RestackCompleted {
+            branch_name: "feat/auth-api-tests".into(),
+            onto_branch: "feat/auth".into(),
+        });
+
+        assert_eq!(
+            animation.render_active(),
+            concat!(
+                "main\n",
+                "└── feat/auth (#42)\n",
+                "    ├── \u{1b}[33m~\u{1b}[0m \u{1b}[33m\u{1b}[9mfeat/auth-api\u{1b}[0m\n",
+                "    │   └── \u{1b}[32m✓\u{1b}[0m \u{1b}[32mfeat/auth-api-tests\u{1b}[0m\n",
+                "    └── \u{1b}[32m✓\u{1b}[0m \u{1b}[32mfeat/auth-ui\u{1b}[0m"
+            )
+        );
+        assert_eq!(
+            animation.render_final(),
+            concat!(
+                "main\n",
+                "└── feat/auth (#42)\n",
+                "    ├── \u{1b}[32m✓\u{1b}[0m \u{1b}[32mfeat/auth-api-tests\u{1b}[0m\n",
+                "    └── \u{1b}[32m✓\u{1b}[0m \u{1b}[32mfeat/auth-ui\u{1b}[0m"
+            )
+        );
+    }
+}

--- a/src/core/clean/apply.rs
+++ b/src/core/clean/apply.rs
@@ -149,10 +149,14 @@ where
     })
 }
 
-pub(crate) fn resume_after_sync(
+pub(crate) fn resume_after_sync_with_reporter<F>(
     pending_operation: PendingOperationState,
     payload: PendingCleanOperation,
-) -> io::Result<CleanApplyOutcome> {
+    reporter: &mut F,
+) -> io::Result<CleanApplyOutcome>
+where
+    F: FnMut(CleanEvent) -> io::Result<()>,
+{
     let mut untracked_branches = payload.untracked_branches;
     let mut session = open_initialized("dig is not initialized; run 'dig init' first")?;
     let mut deleted_branches = payload.deleted_branches;
@@ -161,7 +165,24 @@ pub(crate) fn resume_after_sync(
     let restack_outcome = workflow::continue_resumable_restack_operation(
         &mut session,
         pending_operation,
-        &mut |_| Ok(()),
+        &mut |event| match event {
+            RestackExecutionEvent::Started(action) => reporter(CleanEvent::RebaseStarted {
+                branch_name: action.branch_name.clone(),
+                onto_branch: action.new_base.branch_name.clone(),
+            }),
+            RestackExecutionEvent::Progress { action, progress } => {
+                reporter(CleanEvent::RebaseProgress {
+                    branch_name: action.branch_name.clone(),
+                    onto_branch: action.new_base.branch_name.clone(),
+                    current_commit: progress.current,
+                    total_commits: progress.total,
+                })
+            }
+            RestackExecutionEvent::Completed(action) => reporter(CleanEvent::RebaseCompleted {
+                branch_name: action.branch_name.clone(),
+                onto_branch: action.new_base.branch_name.clone(),
+            }),
+        },
     )?;
     restacked_branches.extend(restack_outcome.restacked_branches.clone());
 
@@ -183,7 +204,7 @@ pub(crate) fn resume_after_sync(
         &payload.current_candidate,
         &mut untracked_branches,
         &mut deleted_branches,
-        &mut |_| Ok(()),
+        reporter,
     )?;
     if !completion_status.success() {
         return Ok(CleanApplyOutcome {
@@ -211,7 +232,7 @@ pub(crate) fn resume_after_sync(
             &mut untracked_branches,
             &mut deleted_branches,
             &mut restacked_branches,
-            &mut |_| Ok(()),
+            reporter,
         )? {
             return Ok(outcome);
         }

--- a/src/core/clean/mod.rs
+++ b/src/core/clean/mod.rs
@@ -2,10 +2,10 @@ mod apply;
 mod plan;
 mod types;
 
-pub(crate) use apply::{apply, apply_with_reporter, resume_after_sync};
+pub(crate) use apply::{apply, apply_with_reporter, resume_after_sync_with_reporter};
 pub(crate) use plan::{
     CleanPlanMode, branch_is_integrated, cleanup_candidate_for_branch, mode_for_sync, plan,
-    plan_for_sync,
+    plan_for_resume, plan_for_sync,
 };
 pub(crate) use types::{
     BlockedBranch, CleanApplyOutcome, CleanBlockReason, CleanCandidate, CleanEvent, CleanOptions,

--- a/src/core/clean/plan.rs
+++ b/src/core/clean/plan.rs
@@ -6,7 +6,10 @@ use crate::core::git::{self, CherryMarker, CommitMetadata};
 use crate::core::graph::BranchGraph;
 use crate::core::restack::{self, RestackBaseTarget};
 use crate::core::store::types::DigState;
-use crate::core::store::{BranchNode, dig_paths, load_config, load_state};
+use crate::core::store::{
+    BranchNode, PendingCleanCandidate, PendingCleanCandidateKind, PendingCleanOperation, dig_paths,
+    load_config, load_state,
+};
 use crate::core::workflow;
 
 use super::types::{
@@ -31,6 +34,36 @@ pub(crate) fn plan(options: &CleanOptions) -> io::Result<CleanPlan> {
 
 pub(crate) fn plan_for_sync() -> io::Result<CleanPlan> {
     plan_with_mode(&CleanOptions::default(), CleanPlanMode::RemoteAwareSync)
+}
+
+pub(crate) fn plan_for_resume(payload: &PendingCleanOperation) -> io::Result<CleanPlan> {
+    let repo = git::resolve_repo_context()?;
+    let store_paths = dig_paths(&repo.git_dir);
+    let state = load_state(&store_paths)?;
+    let current_branch = git::current_branch_name_or(&payload.original_branch)?;
+    let mut candidates = Vec::with_capacity(1 + payload.remaining_candidates.len());
+
+    candidates.push(clean_candidate_from_pending_candidate(
+        &state,
+        &payload.trunk_branch,
+        &payload.current_candidate,
+    )?);
+
+    for candidate in &payload.remaining_candidates {
+        candidates.push(clean_candidate_from_pending_candidate(
+            &state,
+            &payload.trunk_branch,
+            candidate,
+        )?);
+    }
+
+    Ok(CleanPlan {
+        trunk_branch: payload.trunk_branch.clone(),
+        current_branch,
+        requested_branch_name: None,
+        candidates,
+        blocked: Vec::new(),
+    })
 }
 
 pub(crate) fn mode_for_sync(remote_sync_enabled: bool) -> CleanPlanMode {
@@ -315,6 +348,54 @@ fn clean_candidate_from_deleted_step(
         tree: step.tree,
         restack_plan: step.restack_plan,
         depth: step.depth,
+    }
+}
+
+fn clean_candidate_from_pending_candidate(
+    state: &DigState,
+    trunk_branch: &str,
+    candidate: &PendingCleanCandidate,
+) -> io::Result<CleanCandidate> {
+    match &candidate.kind {
+        PendingCleanCandidateKind::DeletedLocally => {
+            let step = deleted_local::plan_deleted_local_step_for_branch(
+                state,
+                trunk_branch,
+                &candidate.branch_name,
+            )?;
+
+            Ok(clean_candidate_from_deleted_step(step))
+        }
+        PendingCleanCandidateKind::IntegratedIntoParent { parent_base } => {
+            let node = state
+                .find_branch_by_name(&candidate.branch_name)
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        format!("tracked branch '{}' was not found", candidate.branch_name),
+                    )
+                })?;
+            let graph = BranchGraph::new(state);
+            let restack_actions = restack::plan_after_branch_detach(
+                state,
+                node.id,
+                &node.branch_name,
+                parent_base,
+                &node.parent,
+            )?;
+
+            Ok(CleanCandidate {
+                node_id: node.id,
+                branch_name: node.branch_name.clone(),
+                parent_branch_name: parent_base.branch_name.clone(),
+                reason: CleanReason::IntegratedIntoParent {
+                    parent_base: parent_base.clone(),
+                },
+                tree: graph.subtree(node.id)?,
+                restack_plan: restack::previews_for_actions(&restack_actions),
+                depth: graph.branch_depth(node.id),
+            })
+        }
     }
 }
 

--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -20,6 +20,47 @@ pub struct SyncOptions {
     pub continue_operation: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SyncStage {
+    LocalSync {
+        phase: PendingSyncPhase,
+        step_branch_name: String,
+        active_branch_name: String,
+        deleted_branches: Vec<String>,
+        restacked_branches: Vec<RestackPreview>,
+    },
+    CleanupResume {
+        plan: clean::CleanPlan,
+        active_branch_name: String,
+        untracked_branches: Vec<String>,
+        deleted_branches: Vec<String>,
+        restacked_branches: Vec<RestackPreview>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SyncEvent {
+    StageStarted(SyncStage),
+    BranchArchived {
+        branch_name: String,
+    },
+    RestackStarted {
+        branch_name: String,
+        onto_branch: String,
+    },
+    RestackProgress {
+        branch_name: String,
+        onto_branch: String,
+        current_commit: usize,
+        total_commits: usize,
+    },
+    RestackCompleted {
+        branch_name: String,
+        onto_branch: String,
+    },
+    Cleanup(clean::CleanEvent),
+}
+
 #[derive(Debug)]
 pub enum SyncCompletion {
     Commit(commit::CommitOutcome),
@@ -137,8 +178,15 @@ struct OutdatedBranchStep {
 }
 
 pub fn run(options: &SyncOptions) -> io::Result<SyncOutcome> {
+    run_with_reporter(options, &mut |_| Ok(()))
+}
+
+pub fn run_with_reporter<F>(options: &SyncOptions, reporter: &mut F) -> io::Result<SyncOutcome>
+where
+    F: FnMut(SyncEvent) -> io::Result<()>,
+{
     if !options.continue_operation {
-        return run_full_sync();
+        return run_full_sync_with_reporter(reporter);
     }
 
     let session = open_initialized("dig is not initialized; run 'dig init' first")?;
@@ -201,8 +249,20 @@ pub fn run(options: &SyncOptions) -> io::Result<SyncOutcome> {
             })
         }
         crate::core::store::PendingOperationKind::Clean(payload) => {
+            let mut restacked_branches = payload.restacked_branches.clone();
+            restacked_branches.extend(pending_operation.completed_branches().iter().cloned());
+            reporter(SyncEvent::StageStarted(SyncStage::CleanupResume {
+                plan: clean::plan_for_resume(&payload)?,
+                active_branch_name: pending_operation.active_action().branch_name.clone(),
+                untracked_branches: payload.untracked_branches.clone(),
+                deleted_branches: payload.deleted_branches.clone(),
+                restacked_branches,
+            }))?;
             let trunk_branch = payload.trunk_branch.clone();
-            let outcome = clean::resume_after_sync(pending_operation, payload)?;
+            let outcome =
+                clean::resume_after_sync_with_reporter(pending_operation, payload, &mut |event| {
+                    reporter(SyncEvent::Cleanup(event))
+                })?;
             let status = outcome.status;
             let failure_output = outcome.failure_output.clone();
             let paused = outcome.paused;
@@ -241,13 +301,16 @@ pub fn run(options: &SyncOptions) -> io::Result<SyncOutcome> {
             })
         }
         crate::core::store::PendingOperationKind::Sync(payload) => {
-            let outcome = resume_full_sync(pending_operation, payload)?;
+            let outcome = resume_full_sync_with_reporter(pending_operation, payload, reporter)?;
             finalize_full_sync_outcome(outcome)
         }
     }
 }
 
-fn run_full_sync() -> io::Result<SyncOutcome> {
+fn run_full_sync_with_reporter<F>(reporter: &mut F) -> io::Result<SyncOutcome>
+where
+    F: FnMut(SyncEvent) -> io::Result<()>,
+{
     let mut session = open_initialized("dig is not initialized; run 'dig init' first")?;
     workflow::ensure_ready_for_operation(&session.repo, "sync")?;
     workflow::ensure_no_pending_operation(&session.paths, "sync")?;
@@ -269,26 +332,41 @@ fn run_full_sync() -> io::Result<SyncOutcome> {
             ..LocalSyncProgress::default()
         },
         remote_sync_enabled,
+        reporter,
     )?;
 
     finalize_full_sync_outcome(outcome)
 }
 
-fn resume_full_sync(
+fn resume_full_sync_with_reporter<F>(
     pending_operation: PendingOperationState,
     payload: PendingSyncOperation,
-) -> io::Result<LocalSyncOutcome> {
+    reporter: &mut F,
+) -> io::Result<LocalSyncOutcome>
+where
+    F: FnMut(SyncEvent) -> io::Result<()>,
+{
     let mut session = open_initialized("dig is not initialized; run 'dig init' first")?;
     let mut progress = LocalSyncProgress {
         repaired_pull_requests: Vec::new(),
         deleted_branches: payload.deleted_branches,
         restacked_branches: payload.restacked_branches,
     };
+    let mut resumed_restacked_branches = progress.restacked_branches.clone();
+    resumed_restacked_branches.extend(pending_operation.completed_branches().iter().cloned());
+
+    reporter(SyncEvent::StageStarted(SyncStage::LocalSync {
+        phase: payload.phase,
+        step_branch_name: payload.step_branch_name.clone(),
+        active_branch_name: pending_operation.active_action().branch_name.clone(),
+        deleted_branches: progress.deleted_branches.clone(),
+        restacked_branches: resumed_restacked_branches,
+    }))?;
 
     let restack_outcome = workflow::continue_resumable_restack_operation(
         &mut session,
         pending_operation,
-        &mut |_| Ok(()),
+        &mut |event| report_restack_event(reporter, event),
     )?;
     progress
         .restacked_branches
@@ -311,6 +389,7 @@ fn resume_full_sync(
         payload.original_branch,
         progress,
         payload.remote_sync_enabled,
+        reporter,
     )
 }
 
@@ -343,12 +422,16 @@ fn finalize_full_sync_outcome(outcome: LocalSyncOutcome) -> io::Result<SyncOutco
     })
 }
 
-fn execute_local_sync(
+fn execute_local_sync<F>(
     session: &mut crate::core::store::StoreSession,
     original_branch: String,
     mut progress: LocalSyncProgress,
     remote_sync_enabled: bool,
-) -> io::Result<LocalSyncOutcome> {
+    reporter: &mut F,
+) -> io::Result<LocalSyncOutcome>
+where
+    F: FnMut(SyncEvent) -> io::Result<()>,
+{
     let cleanup_mode = clean::mode_for_sync(remote_sync_enabled);
 
     loop {
@@ -359,6 +442,7 @@ fn execute_local_sync(
                 &mut progress,
                 step,
                 remote_sync_enabled,
+                reporter,
             )? {
                 return Ok(outcome);
             }
@@ -373,6 +457,7 @@ fn execute_local_sync(
                 &mut progress,
                 step,
                 remote_sync_enabled,
+                reporter,
             )? {
                 return Ok(outcome);
             }
@@ -419,17 +504,35 @@ fn plan_deleted_local_branch_step(
     deleted_local::next_deleted_local_step(&session.state, &session.config.trunk_branch)
 }
 
-fn apply_deleted_local_branch_step(
+fn apply_deleted_local_branch_step<F>(
     session: &mut crate::core::store::StoreSession,
     original_branch: &str,
     progress: &mut LocalSyncProgress,
     step: deleted_local::DeletedLocalBranchStep,
     remote_sync_enabled: bool,
-) -> io::Result<Option<LocalSyncOutcome>> {
+    reporter: &mut F,
+) -> io::Result<Option<LocalSyncOutcome>>
+where
+    F: FnMut(SyncEvent) -> io::Result<()>,
+{
     let restack_actions = deleted_local::restack_actions_for_step(&session.state, &step)?;
 
+    if !restack_actions.is_empty() {
+        report_local_sync_stage_started(
+            reporter,
+            PendingSyncPhase::ReconcileDeletedLocalBranches,
+            &step.branch_name,
+            &restack_actions,
+            progress,
+        )?;
+    }
     deleted_local::archive_deleted_local_step(session, &step)?;
     progress.deleted_branches.push(step.branch_name.clone());
+    if !restack_actions.is_empty() {
+        reporter(SyncEvent::BranchArchived {
+            branch_name: step.branch_name.clone(),
+        })?;
+    }
 
     execute_sync_restack_step(
         session,
@@ -439,6 +542,8 @@ fn apply_deleted_local_branch_step(
         &step.branch_name,
         &restack_actions,
         remote_sync_enabled,
+        reporter,
+        false,
     )
 }
 
@@ -527,13 +632,17 @@ fn plan_outdated_branch_step(
     Ok(None)
 }
 
-fn apply_outdated_branch_step(
+fn apply_outdated_branch_step<F>(
     session: &mut crate::core::store::StoreSession,
     original_branch: &str,
     progress: &mut LocalSyncProgress,
     step: OutdatedBranchStep,
     remote_sync_enabled: bool,
-) -> io::Result<Option<LocalSyncOutcome>> {
+    reporter: &mut F,
+) -> io::Result<Option<LocalSyncOutcome>>
+where
+    F: FnMut(SyncEvent) -> io::Result<()>,
+{
     execute_sync_restack_step(
         session,
         original_branch,
@@ -542,10 +651,12 @@ fn apply_outdated_branch_step(
         &step.branch_name,
         &step.actions,
         remote_sync_enabled,
+        reporter,
+        true,
     )
 }
 
-fn execute_sync_restack_step(
+fn execute_sync_restack_step<F>(
     session: &mut crate::core::store::StoreSession,
     original_branch: &str,
     progress: &mut LocalSyncProgress,
@@ -553,9 +664,18 @@ fn execute_sync_restack_step(
     step_branch_name: &str,
     actions: &[RestackAction],
     remote_sync_enabled: bool,
-) -> io::Result<Option<LocalSyncOutcome>> {
+    reporter: &mut F,
+    emit_stage_started: bool,
+) -> io::Result<Option<LocalSyncOutcome>>
+where
+    F: FnMut(SyncEvent) -> io::Result<()>,
+{
     if actions.is_empty() {
         return Ok(None);
+    }
+
+    if emit_stage_started {
+        report_local_sync_stage_started(reporter, phase, step_branch_name, actions, progress)?;
     }
 
     let restack_outcome = workflow::execute_resumable_restack_operation(
@@ -569,7 +689,7 @@ fn execute_sync_restack_step(
             step_branch_name: step_branch_name.to_string(),
         }),
         actions,
-        &mut |_| Ok(()),
+        &mut |event| report_restack_event(reporter, event),
     )?;
     progress
         .restacked_branches
@@ -588,6 +708,54 @@ fn execute_sync_restack_step(
     }
 
     Ok(None)
+}
+
+fn report_local_sync_stage_started<F>(
+    reporter: &mut F,
+    phase: PendingSyncPhase,
+    step_branch_name: &str,
+    actions: &[RestackAction],
+    progress: &LocalSyncProgress,
+) -> io::Result<()>
+where
+    F: FnMut(SyncEvent) -> io::Result<()>,
+{
+    reporter(SyncEvent::StageStarted(SyncStage::LocalSync {
+        phase,
+        step_branch_name: step_branch_name.to_string(),
+        active_branch_name: actions[0].branch_name.clone(),
+        deleted_branches: progress.deleted_branches.clone(),
+        restacked_branches: progress.restacked_branches.clone(),
+    }))
+}
+
+fn report_restack_event<F>(
+    reporter: &mut F,
+    event: workflow::RestackExecutionEvent<'_>,
+) -> io::Result<()>
+where
+    F: FnMut(SyncEvent) -> io::Result<()>,
+{
+    match event {
+        workflow::RestackExecutionEvent::Started(action) => reporter(SyncEvent::RestackStarted {
+            branch_name: action.branch_name.clone(),
+            onto_branch: action.new_base.branch_name.clone(),
+        }),
+        workflow::RestackExecutionEvent::Progress { action, progress } => {
+            reporter(SyncEvent::RestackProgress {
+                branch_name: action.branch_name.clone(),
+                onto_branch: action.new_base.branch_name.clone(),
+                current_commit: progress.current,
+                total_commits: progress.total,
+            })
+        }
+        workflow::RestackExecutionEvent::Completed(action) => {
+            reporter(SyncEvent::RestackCompleted {
+                branch_name: action.branch_name.clone(),
+                onto_branch: action.new_base.branch_name.clone(),
+            })
+        }
+    }
 }
 
 fn repair_closed_pull_requests_for_deleted_parent_branches(
@@ -1169,7 +1337,10 @@ fn plan_remote_push_action(
 
 #[cfg(test)]
 mod tests {
-    use super::{RemotePushActionKind, plan_remote_pushes, pull_request_needs_repair};
+    use super::{
+        RemotePushActionKind, SyncEvent, SyncOptions, SyncStage, plan_remote_pushes,
+        pull_request_needs_repair, run, run_with_reporter,
+    };
     use crate::core::gh::{PullRequestState, PullRequestStatus};
     use crate::core::test_support::{
         append_file, commit_file, create_tracked_branch, git_ok, initialize_main_repo,
@@ -1322,5 +1493,153 @@ mod tests {
             "feat/auth-ui",
             "feat/auth",
         ));
+    }
+
+    #[test]
+    fn emits_local_sync_restack_events_for_outdated_branch_restack() {
+        with_temp_repo("dig-sync-core", |repo| {
+            initialize_main_repo(repo);
+            crate::core::init::run(&crate::core::init::InitOptions::default()).unwrap();
+            create_tracked_branch("feat/auth");
+            commit_file(repo, "auth.txt", "auth\n", "feat: auth");
+            create_tracked_branch("feat/auth-ui");
+            commit_file(repo, "ui.txt", "ui\n", "feat: ui");
+            git_ok(repo, &["checkout", "feat/auth"]);
+            append_file(repo, "auth.txt", "more\n", "feat: parent follow-up");
+            git_ok(repo, &["checkout", "main"]);
+
+            let mut events = Vec::new();
+            let outcome = run_with_reporter(&SyncOptions::default(), &mut |event| {
+                events.push(event.clone());
+                Ok(())
+            })
+            .unwrap();
+
+            assert!(outcome.status.success());
+            assert!(matches!(
+                &events[0],
+                SyncEvent::StageStarted(SyncStage::LocalSync {
+                    step_branch_name,
+                    active_branch_name,
+                    ..
+                }) if step_branch_name == "feat/auth-ui" && active_branch_name == "feat/auth-ui"
+            ));
+            assert!(events.iter().any(|event| matches!(
+                event,
+                SyncEvent::RestackStarted {
+                    branch_name,
+                    onto_branch,
+                } if branch_name == "feat/auth-ui" && onto_branch == "feat/auth"
+            )));
+            assert!(events.iter().any(|event| matches!(
+                event,
+                SyncEvent::RestackProgress {
+                    branch_name,
+                    current_commit,
+                    total_commits,
+                    ..
+                } if branch_name == "feat/auth-ui" && *current_commit == 1 && *total_commits == 1
+            )));
+            assert!(events.iter().any(|event| matches!(
+                event,
+                SyncEvent::RestackCompleted {
+                    branch_name,
+                    onto_branch,
+                } if branch_name == "feat/auth-ui" && onto_branch == "feat/auth"
+            )));
+        });
+    }
+
+    #[test]
+    fn archives_deleted_local_branch_before_descendant_restack_events() {
+        with_temp_repo("dig-sync-core", |repo| {
+            initialize_main_repo(repo);
+            crate::core::init::run(&crate::core::init::InitOptions::default()).unwrap();
+            create_tracked_branch("feat/auth");
+            commit_file(repo, "auth.txt", "auth\n", "feat: auth");
+            create_tracked_branch("feat/auth-api");
+            commit_file(repo, "api.txt", "api\n", "feat: api");
+            create_tracked_branch("feat/auth-api-tests");
+            commit_file(repo, "tests.txt", "tests\n", "feat: tests");
+            git_ok(repo, &["checkout", "feat/auth"]);
+            git_ok(repo, &["branch", "-D", "feat/auth-api"]);
+
+            let mut events = Vec::new();
+            let outcome = run_with_reporter(&SyncOptions::default(), &mut |event| {
+                events.push(event.clone());
+                Ok(())
+            })
+            .unwrap();
+
+            assert!(outcome.status.success());
+            let archive_index = events
+                .iter()
+                .position(|event| {
+                    matches!(
+                        event,
+                        SyncEvent::BranchArchived { branch_name } if branch_name == "feat/auth-api"
+                    )
+                })
+                .unwrap();
+            let restack_index = events
+                .iter()
+                .position(|event| {
+                    matches!(
+                        event,
+                        SyncEvent::RestackStarted { branch_name, .. }
+                            if branch_name == "feat/auth-api-tests"
+                    )
+                })
+                .unwrap();
+
+            assert!(archive_index < restack_index);
+        });
+    }
+
+    #[test]
+    fn resumes_sync_with_completed_snapshot_and_active_branch() {
+        with_temp_repo("dig-sync-core", |repo| {
+            initialize_main_repo(repo);
+            crate::core::init::run(&crate::core::init::InitOptions::default()).unwrap();
+            create_tracked_branch("feat/auth");
+            commit_file(repo, "auth.txt", "auth\n", "feat: auth");
+            create_tracked_branch("feat/auth-ui");
+            commit_file(repo, "shared.txt", "child\n", "feat: ui");
+            git_ok(repo, &["checkout", "main"]);
+            commit_file(repo, "shared.txt", "main\n", "feat: trunk");
+            git_ok(repo, &["checkout", "feat/auth"]);
+
+            let paused = run(&SyncOptions::default()).unwrap();
+            assert!(!paused.status.success());
+
+            std::fs::write(repo.join("shared.txt"), "resolved\n").unwrap();
+            git_ok(repo, &["add", "shared.txt"]);
+
+            let mut events = Vec::new();
+            let outcome = run_with_reporter(
+                &SyncOptions {
+                    continue_operation: true,
+                },
+                &mut |event| {
+                    events.push(event.clone());
+                    Ok(())
+                },
+            )
+            .unwrap();
+
+            assert!(outcome.status.success());
+            assert!(paused.paused);
+            assert!(matches!(
+                &events[0],
+                SyncEvent::StageStarted(SyncStage::LocalSync {
+                    active_branch_name,
+                    restacked_branches,
+                    ..
+                }) if active_branch_name == "feat/auth-ui"
+                    && restacked_branches
+                        .iter()
+                        .any(|branch| branch.branch_name == "feat/auth")
+            ));
+        });
     }
 }

--- a/src/ui/palette.rs
+++ b/src/ui/palette.rs
@@ -10,6 +10,7 @@ pub enum Accent {
     CommitHash,
     TagRef,
     InFlight,
+    SyncInFlight,
     Success,
     Failure,
 }
@@ -22,6 +23,7 @@ impl Accent {
             Self::CommitHash => "\x1b[33m",
             Self::TagRef => "\x1b[33m",
             Self::InFlight => "\x1b[34m",
+            Self::SyncInFlight => "\x1b[38;5;208m",
             Self::Success => "\x1b[32m",
             Self::Failure => "\x1b[31m",
         }
@@ -36,6 +38,7 @@ impl Accent {
             Self::CommitHash => Color::Yellow,
             Self::TagRef => Color::Yellow,
             Self::InFlight => Color::Blue,
+            Self::SyncInFlight => Color::Indexed(208),
             Self::Success => Color::Green,
             Self::Failure => Color::Red,
         }


### PR DESCRIPTION
This pull request introduces animated progress reporting for the `sync` and `clean` commands, especially when resuming cleanup after a sync operation. It refactors the cleanup resumption logic to support event-driven reporting, adds new animation logic and rendering for the CLI, and improves the planning and tracking of cleanup operations. The changes are grouped below by theme.

**Animated CLI Progress Reporting:**

- Added a `SyncAnimationSession` to `src/cli/sync/mod.rs` that manages terminal animation for both sync and cleanup stages, rendering progress interactively if the output is a terminal. This includes handling transitions between sync and cleanup, and rendering the final state. [[1]](diffhunk://#diff-ed0eaa00819579f598021e5d71b725524c9490baf44968ac12afda1a7dcb5b4bR1-R14) [[2]](diffhunk://#diff-ed0eaa00819579f598021e5d71b725524c9490baf44968ac12afda1a7dcb5b4bL23-R42) [[3]](diffhunk://#diff-ed0eaa00819579f598021e5d71b725524c9490baf44968ac12afda1a7dcb5b4bL141-R166) [[4]](diffhunk://#diff-ed0eaa00819579f598021e5d71b725524c9490baf44968ac12afda1a7dcb5b4bR272-R432)
- Introduced new animation logic in `src/cli/clean/render.rs`, including the `prime_resume` method in `CleanAnimation` to update the animation state when resuming a cleanup, and supporting helpers for clearing in-flight statuses. [[1]](diffhunk://#diff-09d45196d8cadf61bc96969797202faf178ffa4ae9fde2c2b893943b26d16f49R75-R106) [[2]](diffhunk://#diff-09d45196d8cadf61bc96969797202faf178ffa4ae9fde2c2b893943b26d16f49R116-R121) [[3]](diffhunk://#diff-09d45196d8cadf61bc96969797202faf178ffa4ae9fde2c2b893943b26d16f49R139-R148)

**Event-Driven Cleanup Resumption:**

- Refactored the cleanup resumption logic to `resume_after_sync_with_reporter` in `src/core/clean/apply.rs`, allowing progress events to be reported to the CLI for animation. This replaces the old `resume_after_sync` function and wires up event translation for restack and cleanup steps. [[1]](diffhunk://#diff-f0cd93be1956715c610e947ee00f5e72c2c158f70fe6ec6a6590fd96ad1fa5f5L152-R159) [[2]](diffhunk://#diff-f0cd93be1956715c610e947ee00f5e72c2c158f70fe6ec6a6590fd96ad1fa5f5L164-R185) [[3]](diffhunk://#diff-f0cd93be1956715c610e947ee00f5e72c2c158f70fe6ec6a6590fd96ad1fa5f5L186-R207) [[4]](diffhunk://#diff-f0cd93be1956715c610e947ee00f5e72c2c158f70fe6ec6a6590fd96ad1fa5f5L214-R235) [[5]](diffhunk://#diff-773e14cf2cad91d15d536610adf19d1c5813681e83e3b83a0413a21aff3b2ceaL5-R8)

**Sync and Cleanup Planning Enhancements:**

- Added `plan_for_resume` to `src/core/clean/plan.rs`, which reconstructs a `CleanPlan` from a pending cleanup operation, ensuring the CLI can animate the correct set of branches when resuming. [[1]](diffhunk://#diff-50efe08386d6ae0a5af8268d0485999ffadf2cfe4ae70f648a8570f7cc53a799L9-R12) [[2]](diffhunk://#diff-50efe08386d6ae0a5af8268d0485999ffadf2cfe4ae70f648a8570f7cc53a799R39-R68) [[3]](diffhunk://#diff-50efe08386d6ae0a5af8268d0485999ffadf2cfe4ae70f648a8570f7cc53a799R354-R401)

**Sync Event Model Extension:**

- Introduced `SyncStage` and extended `SyncEvent` in `src/core/sync.rs` to provide a richer event model for both sync and cleanup phases, supporting more granular and accurate animation.

**Testing and Internal Visibility:**

- Added a test for the new `prime_resume` animation logic in `CleanAnimation` and made the `render` module public within `src/cli/clean/mod.rs` to allow reuse from `sync`. [[1]](diffhunk://#diff-09d45196d8cadf61bc96969797202faf178ffa4ae9fde2c2b893943b26d16f49R255-R308) [[2]](diffhunk://#diff-cd8fa02324c1b21119f797dd05afecb9840676d986aa5b1d55bcfb4317385584L1-R1)

These changes collectively enable a much more interactive and informative CLI experience during complex sync and cleanup operations, especially when operations are resumed after interruption.