### PR TITLE
fix: validate state integrity after loading state.json

### DIFF
--- a/src/core/store/state.rs
+++ b/src/core/store/state.rs
@@ -10,8 +10,10 @@ pub fn load_state(paths: &DaggerPaths) -> io::Result<DaggerState> {
     }
 
     let bytes = fs::read(&paths.state_file)?;
-    let state = serde_json::from_slice(&bytes)
+    let state: DaggerState = serde_json::from_slice(&bytes)
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+
+    state.validate()?;
 
     Ok(state)
 }

--- a/src/core/store/types.rs
+++ b/src/core/store/types.rs
@@ -72,15 +72,38 @@ impl DaggerState {
                 ));
             }
 
-            if let ParentRef::Branch { node_id } = &node.parent {
-                if !all_ids.contains(node_id) {
+            if let ParentRef::Branch { node_id: parent_id } = &node.parent {
+                if *parent_id == node.id {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "branch '{}' references itself as parent",
+                            node.branch_name
+                        ),
+                    ));
+                }
+                if !all_ids.contains(parent_id) {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         format!(
                             "branch '{}' references non-existent parent node {}",
-                            node.branch_name, node_id
+                            node.branch_name, parent_id
                         ),
                     ));
+                }
+                // Warn if an active node references an archived parent
+                if !node.archived {
+                    if let Some(parent_node) = self.nodes.iter().find(|n| n.id == *parent_id) {
+                        if parent_node.archived {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                format!(
+                                    "active branch '{}' references archived parent '{}'",
+                                    node.branch_name, parent_node.branch_name
+                                ),
+                            ));
+                        }
+                    }
                 }
             }
         }
@@ -472,7 +495,7 @@ mod tests {
         BranchNode, BranchPullRequestTrackedEvent, BranchPullRequestTrackedSource, DaggerConfig,
         DaggerEvent, DaggerState, ParentRef, PendingCommitOperation, PendingOperationKind,
         PendingOperationState, PendingOrphanOperation, PendingReparentOperation,
-        PendingSyncOperation, PendingSyncPhase, TrackedPullRequest,
+        PendingSyncOperation, PendingSyncPhase, TrackedPullRequest, DAGGER_STATE_VERSION,
     };
     use crate::core::restack::{RestackAction, RestackBaseTarget};
     use uuid::Uuid;
@@ -735,7 +758,7 @@ mod tests {
         let child = make_node("feature/child", ParentRef::Branch { node_id: parent.id });
 
         let state = DaggerState {
-            version: 1,
+            version: DAGGER_STATE_VERSION,
             nodes: vec![parent, child],
         };
 
@@ -763,7 +786,7 @@ mod tests {
         b.id = shared_id;
 
         let state = DaggerState {
-            version: 1,
+            version: DAGGER_STATE_VERSION,
             nodes: vec![a, b],
         };
 
@@ -777,7 +800,7 @@ mod tests {
         let b = make_node("feature/dup", ParentRef::Trunk);
 
         let state = DaggerState {
-            version: 1,
+            version: DAGGER_STATE_VERSION,
             nodes: vec![a, b],
         };
 
@@ -791,7 +814,7 @@ mod tests {
         let node = make_node("feature/orphan", ParentRef::Branch { node_id: dangling_id });
 
         let state = DaggerState {
-            version: 1,
+            version: DAGGER_STATE_VERSION,
             nodes: vec![node],
         };
 
@@ -806,10 +829,40 @@ mod tests {
         let active = make_node("feature/dup", ParentRef::Trunk);
 
         let state = DaggerState {
-            version: 1,
+            version: DAGGER_STATE_VERSION,
             nodes: vec![archived, active],
         };
 
         assert!(state.validate().is_ok());
+    }
+
+    #[test]
+    fn validates_self_parent_reference() {
+        let mut node = make_node("feature/self-ref", ParentRef::Trunk);
+        let self_id = node.id;
+        node.parent = ParentRef::Branch { node_id: self_id };
+
+        let state = DaggerState {
+            version: DAGGER_STATE_VERSION,
+            nodes: vec![node],
+        };
+
+        let err = state.validate().unwrap_err();
+        assert!(err.to_string().contains("references itself as parent"));
+    }
+
+    #[test]
+    fn validates_active_node_with_archived_parent() {
+        let mut parent = make_node("feature/parent", ParentRef::Trunk);
+        parent.archived = true;
+        let child = make_node("feature/child", ParentRef::Branch { node_id: parent.id });
+
+        let state = DaggerState {
+            version: DAGGER_STATE_VERSION,
+            nodes: vec![parent, child],
+        };
+
+        let err = state.validate().unwrap_err();
+        assert!(err.to_string().contains("archived parent"));
     }
 }

--- a/src/core/store/types.rs
+++ b/src/core/store/types.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::io;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -41,6 +42,52 @@ impl Default for DaggerState {
 }
 
 impl DaggerState {
+    pub fn validate(&self) -> io::Result<()> {
+        if self.version != DAGGER_STATE_VERSION {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "unsupported state version {} (expected {})",
+                    self.version, DAGGER_STATE_VERSION
+                ),
+            ));
+        }
+
+        let mut seen_ids = HashSet::new();
+        let mut seen_names = HashSet::new();
+        let all_ids: HashSet<Uuid> = self.nodes.iter().map(|n| n.id).collect();
+
+        for node in &self.nodes {
+            if !seen_ids.insert(node.id) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("duplicate node id {}", node.id),
+                ));
+            }
+
+            if !node.archived && !seen_names.insert(&node.branch_name) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("duplicate active branch name '{}'", node.branch_name),
+                ));
+            }
+
+            if let ParentRef::Branch { node_id } = &node.parent {
+                if !all_ids.contains(node_id) {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "branch '{}' references non-existent parent node {}",
+                            node.branch_name, node_id
+                        ),
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn find_branch_by_name(&self, branch_name: &str) -> Option<&BranchNode> {
         self.nodes
             .iter()
@@ -665,5 +712,104 @@ mod tests {
 
         assert!(serialized.contains("\"type\":\"branch_archived\""));
         assert!(serialized.contains("\"kind\":\"deleted_locally\""));
+    }
+
+    fn make_node(name: &str, parent: ParentRef) -> BranchNode {
+        BranchNode {
+            id: Uuid::new_v4(),
+            branch_name: name.into(),
+            parent,
+            base_ref: "main".into(),
+            fork_point_oid: "abc123".into(),
+            head_oid_at_creation: "abc123".into(),
+            created_at_unix_secs: 1,
+            divergence_state: BranchDivergenceState::Unknown,
+            pull_request: None,
+            archived: false,
+        }
+    }
+
+    #[test]
+    fn validates_valid_state() {
+        let parent = make_node("feature/parent", ParentRef::Trunk);
+        let child = make_node("feature/child", ParentRef::Branch { node_id: parent.id });
+
+        let state = DaggerState {
+            version: 1,
+            nodes: vec![parent, child],
+        };
+
+        assert!(state.validate().is_ok());
+    }
+
+    #[test]
+    fn validates_version_mismatch() {
+        let state = DaggerState {
+            version: 999,
+            nodes: Vec::new(),
+        };
+
+        let err = state.validate().unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("unsupported state version 999"));
+    }
+
+    #[test]
+    fn validates_duplicate_node_ids() {
+        let mut a = make_node("feature/a", ParentRef::Trunk);
+        let mut b = make_node("feature/b", ParentRef::Trunk);
+        let shared_id = Uuid::new_v4();
+        a.id = shared_id;
+        b.id = shared_id;
+
+        let state = DaggerState {
+            version: 1,
+            nodes: vec![a, b],
+        };
+
+        let err = state.validate().unwrap_err();
+        assert!(err.to_string().contains("duplicate node id"));
+    }
+
+    #[test]
+    fn validates_duplicate_active_branch_names() {
+        let a = make_node("feature/dup", ParentRef::Trunk);
+        let b = make_node("feature/dup", ParentRef::Trunk);
+
+        let state = DaggerState {
+            version: 1,
+            nodes: vec![a, b],
+        };
+
+        let err = state.validate().unwrap_err();
+        assert!(err.to_string().contains("duplicate active branch name"));
+    }
+
+    #[test]
+    fn validates_dangling_parent_reference() {
+        let dangling_id = Uuid::new_v4();
+        let node = make_node("feature/orphan", ParentRef::Branch { node_id: dangling_id });
+
+        let state = DaggerState {
+            version: 1,
+            nodes: vec![node],
+        };
+
+        let err = state.validate().unwrap_err();
+        assert!(err.to_string().contains("non-existent parent node"));
+    }
+
+    #[test]
+    fn validates_archived_duplicate_names_allowed() {
+        let mut archived = make_node("feature/dup", ParentRef::Trunk);
+        archived.archived = true;
+        let active = make_node("feature/dup", ParentRef::Trunk);
+
+        let state = DaggerState {
+            version: 1,
+            nodes: vec![archived, active],
+        };
+
+        assert!(state.validate().is_ok());
     }
 }

--- a/src/core/store/types.rs
+++ b/src/core/store/types.rs
@@ -76,10 +76,7 @@ impl DaggerState {
                 if *parent_id == node.id {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidData,
-                        format!(
-                            "branch '{}' references itself as parent",
-                            node.branch_name
-                        ),
+                        format!("branch '{}' references itself as parent", node.branch_name),
                     ));
                 }
                 if !all_ids.contains(parent_id) {
@@ -492,10 +489,11 @@ pub fn now_unix_timestamp_secs() -> u64 {
 mod tests {
     use super::{
         BranchAdoptedEvent, BranchArchiveReason, BranchArchivedEvent, BranchDivergenceState,
-        BranchNode, BranchPullRequestTrackedEvent, BranchPullRequestTrackedSource, DaggerConfig,
-        DaggerEvent, DaggerState, ParentRef, PendingCommitOperation, PendingOperationKind,
-        PendingOperationState, PendingOrphanOperation, PendingReparentOperation,
-        PendingSyncOperation, PendingSyncPhase, TrackedPullRequest, DAGGER_STATE_VERSION,
+        BranchNode, BranchPullRequestTrackedEvent, BranchPullRequestTrackedSource,
+        DAGGER_STATE_VERSION, DaggerConfig, DaggerEvent, DaggerState, ParentRef,
+        PendingCommitOperation, PendingOperationKind, PendingOperationState,
+        PendingOrphanOperation, PendingReparentOperation, PendingSyncOperation, PendingSyncPhase,
+        TrackedPullRequest,
     };
     use crate::core::restack::{RestackAction, RestackBaseTarget};
     use uuid::Uuid;
@@ -811,7 +809,12 @@ mod tests {
     #[test]
     fn validates_dangling_parent_reference() {
         let dangling_id = Uuid::new_v4();
-        let node = make_node("feature/orphan", ParentRef::Branch { node_id: dangling_id });
+        let node = make_node(
+            "feature/orphan",
+            ParentRef::Branch {
+                node_id: dangling_id,
+            },
+        );
 
         let state = DaggerState {
             version: DAGGER_STATE_VERSION,

--- a/src/core/store/types.rs
+++ b/src/core/store/types.rs
@@ -88,20 +88,9 @@ impl DaggerState {
                         ),
                     ));
                 }
-                // Warn if an active node references an archived parent
-                if !node.archived {
-                    if let Some(parent_node) = self.nodes.iter().find(|n| n.id == *parent_id) {
-                        if parent_node.archived {
-                            return Err(io::Error::new(
-                                io::ErrorKind::InvalidData,
-                                format!(
-                                    "active branch '{}' references archived parent '{}'",
-                                    node.branch_name, parent_node.branch_name
-                                ),
-                            ));
-                        }
-                    }
-                }
+                // Note: an active node referencing an archived parent is a valid
+                // intermediate state that the sync command is designed to repair.
+                // We intentionally do not reject it here.
             }
         }
 
@@ -855,7 +844,7 @@ mod tests {
     }
 
     #[test]
-    fn validates_active_node_with_archived_parent() {
+    fn validates_active_node_with_archived_parent_is_allowed() {
         let mut parent = make_node("feature/parent", ParentRef::Trunk);
         parent.archived = true;
         let child = make_node("feature/child", ParentRef::Branch { node_id: parent.id });
@@ -865,7 +854,8 @@ mod tests {
             nodes: vec![parent, child],
         };
 
-        let err = state.validate().unwrap_err();
-        assert!(err.to_string().contains("archived parent"));
+        // An active node referencing an archived parent is a valid intermediate
+        // state that sync is designed to repair, so validation must accept it.
+        assert!(state.validate().is_ok());
     }
 }


### PR DESCRIPTION
## Why?

A corrupted or manually edited `state.json` can cause `dgr` to panic, silently produce wrong results, or corrupt data further. Early validation with clear error messages makes debugging straightforward and prevents cascading failures.

## Summary

- Adds a `validate()` method to `DaggerState` that checks referential integrity after deserializing `state.json`: version compatibility, duplicate node IDs, duplicate active branch names, self-referential parents, and dangling parent references
- Calls `validate()` in `load_state` immediately after deserialization so corrupted state is caught early with clear error messages
- Intentionally allows active branches to reference archived parents — this is a valid intermediate state that `dgr sync` repairs
- Adds unit tests covering valid state, version mismatch, duplicate IDs, duplicate active names, dangling parent refs, self-parenting, and archived duplicate names being allowed

Refs: #10 (item 4 — state validation)

## Test plan

- [x] `cargo test --locked` passes with all new validation tests
- [ ] Existing state files load without validation errors
- [ ] Manually corrupt `state.json` (e.g. duplicate a node ID) and verify `dgr` reports a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)