### PR TITLE
ci: add cargo clippy lint step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt
+          components: rustfmt, clippy
 
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@v2
@@ -34,6 +34,9 @@ jobs:
 
       - name: Run cargo check
         run: cargo check --locked --all-targets
+
+      - name: Run cargo clippy
+        run: cargo clippy --locked --all-targets -- -D warnings
 
       - name: Run cargo test
         run: cargo test --locked


### PR DESCRIPTION
## Why?

Clippy catches common Rust mistakes, performance issues, and style violations that `cargo check` misses. Running it in CI prevents these from accumulating — a lint-clean codebase is easier to maintain and review.

## Summary

- Add `clippy` component to the Rust toolchain installation
- Add a `cargo clippy --locked --all-targets -- -D warnings` step after `cargo check` in CI

Addresses item 1 in #11.

## Test plan

- [ ] CI passes with the new clippy step
- [ ] Intentionally introduce a clippy warning and verify CI fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)