### PR TITLE
ci: add Dependabot for cargo and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## Why?

Dependencies with known vulnerabilities or outdated actions can introduce security risks and subtle breakage. Dependabot automates the tedious work of monitoring and proposing updates, keeping the supply chain current without manual effort.

## Summary

- Add `.github/dependabot.yml` to enable automated dependency updates
- Configures weekly Cargo dependency updates (prefixed `deps`)
- Configures weekly GitHub Actions updates (prefixed `ci`)

Addresses item 5 in #11.

## Test plan

- [ ] Verify Dependabot opens PRs on the configured schedule
- [ ] Confirm PR prefixes match the configured commit-message settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)