### PR TITLE
ci: add MSRV verification for Rust 1.85

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,19 @@ jobs:
 
       - name: Run cargo test
         run: cargo test --locked
+
+  msrv:
+    name: MSRV Check
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Install minimum supported Rust version
+        uses: dtolnay/rust-toolchain@1.85
+
+      - name: Restore Cargo cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run cargo check
+        run: cargo check --locked --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "dagger"
 version = "0.2.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
+rust-version = "1.85"
 
 [[bin]]
 name = "dgr"


### PR DESCRIPTION
## Why?

Without an explicit MSRV (minimum supported Rust version), contributors can unknowingly use newer language features that break the build for users on older toolchains. Declaring and testing the MSRV in CI catches these regressions before they're merged.

## Summary

- Add `rust-version = "1.85"` to `Cargo.toml` to declare the minimum supported Rust version
- Add a dedicated `msrv` job to the CI workflow that runs `cargo check` with Rust 1.85
- Ensures future changes don't accidentally require a newer Rust version

Addresses item 4 in #11.

## Test plan

- [ ] CI `msrv` job passes with Rust 1.85
- [ ] Existing `verify` job remains unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)