### PR TITLE
fix: add --version flag to CLI

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -21,6 +21,7 @@ use clap::{Parser, Subcommand};
 #[derive(Parser, Debug)]
 #[command(name = "dgr")]
 #[command(about = "Git wrapper for stacked PR workflows")]
+#[command(version)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,


### PR DESCRIPTION
## Summary
- Adds `#[command(version)]` attribute to the `Cli` struct so that `dgr --version` prints the crate version from `Cargo.toml`.

Refs #11 (item 7).

## Test plan
- [ ] Run `cargo run -- --version` and confirm it prints the version string
- [ ] Run `cargo run -- --help` and confirm `--version` appears in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)