### PR TITLE
ci: add CodeRabbit.ai review configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,9 +1,14 @@
-language: en
+# CodeRabbit configuration
+# https://docs.coderabbit.ai/guides/configure-coderabbit
+language: en-US
 reviews:
-  profile: chill
   auto_review:
     enabled: true
     drafts: false
+    base_branches:
+      - main
+  path_filters:
+    - "!.claude/**"
   path_instructions:
     - path: "src/core/store/**"
       instructions: >
@@ -19,6 +24,18 @@ reviews:
       instructions: >
         Verify CLI layer is a thin adapter. Business logic should live in
         src/core/. Check that error messages are user-friendly.
+    - path: "**/*.rs"
+      instructions: >
+        Focus on Rust best practices, proper error handling, and security
+        considerations. Flag any potential issues with unsafe code or
+        subprocess command injection.
+    - path: "**/*.yml"
+      instructions: >
+        Focus on YAML best practices, correct indentation, valid syntax,
+        and consistent structure. Flag any schema issues or misconfigurations.
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
   tools:
     clippy:
       enabled: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -23,7 +23,7 @@ reviews:
     - path: "src/cli/**"
       instructions: >
         Verify CLI layer is a thin adapter. Business logic should live in
-        src/core/. Check that error messages are user-friendly.
+        src/core/ instead. Check that error messages are user-friendly.
     - path: "**/*.rs"
       instructions: >
         Focus on Rust best practices, proper error handling, and security

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,28 @@
+language: en
+reviews:
+  profile: chill
+  auto_review:
+    enabled: true
+    drafts: false
+  path_instructions:
+    - path: "src/core/store/**"
+      instructions: >
+        Pay close attention to atomicity, error handling on I/O operations,
+        and state consistency. These files manage persistent state that must
+        survive crashes.
+    - path: "src/core/git.rs"
+      instructions: >
+        Review for command injection risks in git subprocess invocations.
+        Ensure all user-provided branch names are passed as separate args,
+        never interpolated into shell strings.
+    - path: "src/cli/**"
+      instructions: >
+        Verify CLI layer is a thin adapter. Business logic should live in
+        src/core/. Check that error messages are user-friendly.
+  tools:
+    clippy:
+      enabled: true
+    shellcheck:
+      enabled: true
+chat:
+  auto_reply: true


### PR DESCRIPTION
## Why?

Manual code review is time-consuming and easy to miss subtle issues in. CodeRabbit provides AI-powered review with domain-specific context (e.g., understanding that store operations need atomicity, or that CLI output must be deterministic). This complements human review rather than replacing it.

## Summary

- Add `.coderabbit.yaml` with path-specific review instructions for store, git, and CLI modules
- Enable clippy and shellcheck review tools
- Set review profile to "chill" with auto-review on non-draft PRs

Refs #11 (item 10)

## Note for maintainer

The CodeRabbit GitHub App must be installed on the **oneirosoft/dagger** repository for this configuration to take effect. Install it at https://coderabbit.ai — it is **free for open-source repos**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)