### PR TITLE
ci: add SonarCloud continuous inspection

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,25 @@
+name: SonarCloud
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  sonarcloud:
+    name: SonarCloud Analysis
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,25 +1,26 @@
-name: SonarCloud
+name: SonarCloud Analysis
+
+permissions: {}
 
 on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened]
-
-permissions:
-  contents: read
+    branches: [main]
 
 jobs:
   sonarcloud:
-    name: SonarCloud Analysis
-    runs-on: ubuntu-24.04
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v5
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        if: ${{ env.SONAR_TOKEN != '' }}
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,5 @@ sonar.projectKey=oneirosoft_dagger
 sonar.organization=oneirosoft
 sonar.projectName=dagger
 sonar.sources=src
-sonar.tests=tests
 sonar.sourceEncoding=UTF-8
 sonar.exclusions=**/test_support.rs,.claude/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectKey=oneirosoft_dagger
+sonar.organization=oneirosoft
+sonar.sources=src
+sonar.tests=tests
+sonar.sourceEncoding=UTF-8
+sonar.exclusions=**/test_support.rs

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,7 @@
 sonar.projectKey=oneirosoft_dagger
 sonar.organization=oneirosoft
+sonar.projectName=dagger
 sonar.sources=src
 sonar.tests=tests
 sonar.sourceEncoding=UTF-8
-sonar.exclusions=**/test_support.rs
+sonar.exclusions=**/test_support.rs,.claude/**


### PR DESCRIPTION
## Why?

SonarCloud provides continuous code quality inspection — tracking bugs, code smells, security vulnerabilities, and test coverage over time. Unlike one-shot linters, it maintains a historical baseline so quality trends are visible and regressions are caught as they happen.

## Summary

- Adds `sonar-project.properties` with project configuration for SonarCloud
- Adds `.github/workflows/sonarcloud.yml` GitHub Actions workflow that runs SonarCloud analysis on pushes to `main` and on pull requests
- Fork PRs are handled gracefully — the scan step is skipped when `SONAR_TOKEN` is unavailable

Relates to #11 (item 9 — SonarCloud / SonarQube integration).

## Maintainer setup required

1. **Create a SonarCloud account** at [sonarcloud.io](https://sonarcloud.io) and import the `oneirosoft/dagger` repository
2. **Add the `SONAR_TOKEN` secret** to the GitHub repository settings (Settings → Secrets and variables → Actions → New repository secret)

## Test plan

- [ ] Verify the workflow triggers on push to `main` and on PRs
- [ ] Confirm SonarCloud scan completes successfully once the token is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)