### PR TITLE
[codex] Refresh trunk before sync restack

### DIFF
--- a/src/cli/sync/render.rs
+++ b/src/cli/sync/render.rs
@@ -334,6 +334,10 @@ fn format_branch_text(branch_name: &str, pull_request_number: Option<u64>) -> St
 fn format_status_text(status: &SyncStatus) -> String {
     match status {
         SyncStatus::FetchingRemotes => "Fetching remotes".to_string(),
+        SyncStatus::RefreshingTrunk {
+            branch_name,
+            remote_name,
+        } => format!("Refreshing {branch_name} from {remote_name}"),
         SyncStatus::RepairingClosedPullRequests => "Repairing closed pull requests".to_string(),
         SyncStatus::RemovingMergedLocalBranches => "Removing merged local branches".to_string(),
         SyncStatus::ReconcilingDeletedLocalBranch { step_branch_name } => {
@@ -529,6 +533,23 @@ mod tests {
         assert_eq!(
             render_active_frame(Some((&SyncStatus::FetchingRemotes, 0)), None),
             "\u{1b}[38;5;208mFetching remotes\u{1b}[0m \u{1b}[38;5;208m|\u{1b}[0m"
+        );
+    }
+
+    #[test]
+    fn renders_trunk_refresh_status_bar() {
+        assert_eq!(
+            render_active_frame(
+                Some((
+                    &SyncStatus::RefreshingTrunk {
+                        branch_name: "main".into(),
+                        remote_name: "origin".into(),
+                    },
+                    0
+                )),
+                None,
+            ),
+            "\u{1b}[38;5;208mRefreshing main from origin\u{1b}[0m \u{1b}[38;5;208m|\u{1b}[0m"
         );
     }
 

--- a/src/core/git.rs
+++ b/src/core/git.rs
@@ -389,8 +389,12 @@ pub fn branch_push_target_if_needed(branch_name: &str) -> io::Result<Option<Bran
     Ok(Some(target))
 }
 
+pub fn branch_remote_name(branch_name: &str) -> io::Result<Option<String>> {
+    resolve_push_remote_name(branch_name)
+}
+
 pub fn branch_push_target(branch_name: &str) -> io::Result<Option<BranchPushTarget>> {
-    let Some(remote_name) = resolve_push_remote_name(branch_name)? else {
+    let Some(remote_name) = branch_remote_name(branch_name)? else {
         return Ok(None);
     };
 
@@ -458,6 +462,21 @@ pub fn fetch_remote(remote_name: &str) -> io::Result<GitCommandOutput> {
         .output()?;
 
     output_to_git_command_output(output)
+}
+
+pub fn pull_branch_with_rebase(
+    remote_name: &str,
+    branch_name: &str,
+) -> io::Result<GitCommandOutput> {
+    let output = Command::new("git")
+        .args(["pull", "--rebase", remote_name, branch_name])
+        .output()?;
+
+    output_to_git_command_output(output)
+}
+
+pub fn abort_rebase() -> io::Result<GitCommandOutput> {
+    run_git_capture_output(["rebase", "--abort"])
 }
 
 pub fn remote_tracking_ref_name(remote_name: &str, branch_name: &str) -> String {

--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -41,6 +41,10 @@ pub enum SyncStage {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SyncStatus {
     FetchingRemotes,
+    RefreshingTrunk {
+        branch_name: String,
+        remote_name: String,
+    },
     RepairingClosedPullRequests,
     RemovingMergedLocalBranches,
     ReconcilingDeletedLocalBranch {
@@ -395,8 +399,10 @@ where
     workflow::ensure_ready_for_operation(&session.repo, "sync")?;
     workflow::ensure_no_pending_operation(&session.paths, "sync")?;
     clean::reconcile_branch_divergence_state(&mut session)?;
+    let original_branch = git::current_branch_name()?;
     reporter(SyncEvent::StatusChanged(SyncStatus::FetchingRemotes))?;
     let remote_sync_enabled = fetch_sync_remotes(&session)?;
+    refresh_trunk_before_sync(&session, &original_branch, reporter)?;
     let repaired_pull_requests = if remote_sync_enabled {
         reporter(SyncEvent::StatusChanged(
             SyncStatus::RepairingClosedPullRequests,
@@ -405,7 +411,6 @@ where
     } else {
         Vec::new()
     };
-    let original_branch = git::current_branch_name()?;
     if remote_sync_enabled {
         reporter(SyncEvent::StatusChanged(
             SyncStatus::RemovingMergedLocalBranches,
@@ -1295,6 +1300,98 @@ fn fetch_sync_remotes(session: &crate::core::store::StoreSession) -> io::Result<
     Ok(true)
 }
 
+fn refresh_trunk_before_sync<F>(
+    session: &crate::core::store::StoreSession,
+    original_branch: &str,
+    reporter: &mut F,
+) -> io::Result<()>
+where
+    F: FnMut(SyncEvent) -> io::Result<()>,
+{
+    let trunk_branch = &session.config.trunk_branch;
+    if !git::branch_exists(trunk_branch)? {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("trunk branch '{}' does not exist", trunk_branch),
+        ));
+    }
+
+    let Some(remote_name) = git::branch_remote_name(trunk_branch)? else {
+        return Ok(());
+    };
+
+    reporter(SyncEvent::StatusChanged(SyncStatus::RefreshingTrunk {
+        branch_name: trunk_branch.clone(),
+        remote_name: remote_name.clone(),
+    }))?;
+
+    let pull_output =
+        workflow::pull_branch_with_rebase(trunk_branch, &remote_name).map_err(|error| {
+            preflight_sync_error(
+                &session.repo,
+                original_branch,
+                format!(
+                    "failed to refresh trunk '{}' from '{}': {}",
+                    trunk_branch, remote_name, error
+                ),
+            )
+        })?;
+
+    if pull_output.status.success() {
+        return Ok(());
+    }
+
+    let combined_output = pull_output.combined_output();
+    let message = if combined_output.is_empty() {
+        format!("git pull --rebase '{remote_name}' '{trunk_branch}' failed")
+    } else {
+        format!("git pull --rebase '{remote_name}' '{trunk_branch}' failed: {combined_output}")
+    };
+
+    Err(preflight_sync_error(
+        &session.repo,
+        original_branch,
+        message,
+    ))
+}
+
+fn preflight_sync_error(
+    repo: &git::RepoContext,
+    original_branch: &str,
+    message: String,
+) -> io::Error {
+    let mut detail = message;
+
+    if git::is_rebase_in_progress(repo) {
+        match git::abort_rebase() {
+            Ok(output) if output.status.success() => {}
+            Ok(output) => {
+                let combined_output = output.combined_output();
+                detail = if combined_output.is_empty() {
+                    format!("{detail}\nfailed to abort trunk refresh rebase")
+                } else {
+                    format!("{detail}\nfailed to abort trunk refresh rebase: {combined_output}")
+                };
+            }
+            Err(error) => {
+                detail = format!("{detail}\nfailed to abort trunk refresh rebase: {}", error);
+            }
+        }
+    }
+
+    match workflow::restore_original_branch_if_needed(original_branch) {
+        Ok(Some(outcome)) if !outcome.status.success() => io::Error::other(format!(
+            "{detail}\nfailed to return to '{}'",
+            original_branch
+        )),
+        Err(error) => io::Error::other(format!(
+            "{detail}\nfailed to return to '{}': {}",
+            original_branch, error
+        )),
+        _ => io::Error::other(detail),
+    }
+}
+
 pub fn plan_remote_pushes(
     restacked_branch_names: &[String],
     excluded_branch_names: &[String],
@@ -1798,6 +1895,18 @@ mod tests {
                     matches!(event, SyncEvent::StatusChanged(SyncStatus::FetchingRemotes))
                 })
                 .unwrap();
+            let refresh_index = events
+                .iter()
+                .position(|event| {
+                    matches!(
+                        event,
+                        SyncEvent::StatusChanged(SyncStatus::RefreshingTrunk {
+                            branch_name,
+                            remote_name,
+                        }) if branch_name == "main" && remote_name == "origin"
+                    )
+                })
+                .unwrap();
             let repair_index = events
                 .iter()
                 .position(|event| {
@@ -1823,7 +1932,8 @@ mod tests {
                 })
                 .unwrap();
 
-            assert!(fetch_index < repair_index);
+            assert!(fetch_index < refresh_index);
+            assert!(refresh_index < repair_index);
             assert!(repair_index < prune_index);
             assert!(prune_index < stage_index);
         });

--- a/src/core/workflow.rs
+++ b/src/core/workflow.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::process::ExitStatus;
 
-use crate::core::git::{self, RebaseProgress, RepoContext};
+use crate::core::git::{self, GitCommandOutput, RebaseProgress, RepoContext};
 use crate::core::restack::{self, RestackAction, RestackPreview};
 use crate::core::store::fs::DaggerPaths;
 use crate::core::store::session::StoreSession;
@@ -113,6 +113,21 @@ pub(crate) fn restore_original_branch_if_needed(
         status,
         restored_branch: original_branch.to_string(),
     }))
+}
+
+pub(crate) fn pull_branch_with_rebase(
+    target_branch: &str,
+    remote_name: &str,
+) -> io::Result<GitCommandOutput> {
+    let checkout = checkout_branch_if_needed(target_branch)?;
+    if !checkout.status.success() {
+        return Err(io::Error::other(format!(
+            "failed to switch to '{}' before pulling from '{}'",
+            target_branch, remote_name
+        )));
+    }
+
+    git::pull_branch_with_rebase(remote_name, target_branch)
 }
 
 pub(crate) fn execute_resumable_restack_operation<F>(

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -106,12 +106,7 @@ fn setup_remotely_merged_root_branch_with_local_trunk_advance(repo: &Path) {
     dgr_ok(repo, &["branch", "feat/auth-ui"]);
     commit_file(repo, "ui.txt", "ui\n", "feat: ui");
     git_ok(repo, &["checkout", "main"]);
-    overwrite_file(
-        repo,
-        "shared.txt",
-        "local trunk\n",
-        "feat: local trunk follow-up",
-    );
+    overwrite_file(repo, "README.md", "root\nlocal trunk\n", "feat: local trunk follow-up");
 
     let remote_repo = clone_origin(repo, "origin-worktree");
     git_ok(&remote_repo, &["checkout", "main"]);
@@ -146,12 +141,7 @@ fn setup_remotely_merged_root_branch_with_children(
     }
 
     git_ok(repo, &["checkout", "main"]);
-    overwrite_file(
-        repo,
-        "shared.txt",
-        "local trunk\n",
-        "feat: local trunk follow-up",
-    );
+    overwrite_file(repo, "README.md", "root\nlocal trunk\n", "feat: local trunk follow-up");
 
     let remote_repo = clone_origin(repo, "origin-worktree");
     git_ok(&remote_repo, &["checkout", "main"]);
@@ -864,6 +854,100 @@ fn sync_aborts_before_local_restack_when_fetch_fails() {
             git_stdout(repo, &["rev-parse", "main"])
         );
         assert!(load_operation_json(repo).is_none());
+    });
+}
+
+#[test]
+fn sync_refreshes_local_trunk_before_restacking_local_only_branch() {
+    with_temp_repo("dgr-sync-cli", |repo| {
+        initialize_main_repo(repo);
+        initialize_origin_remote(repo);
+        dgr_ok(repo, &["init"]);
+        dgr_ok(repo, &["branch", "feat/auth"]);
+        commit_file(repo, "auth.txt", "auth\n", "feat: auth");
+
+        let remote_repo = clone_origin(repo, "origin-worktree-local-only");
+        git_ok(&remote_repo, &["checkout", "main"]);
+        commit_file(
+            &remote_repo,
+            "README.md",
+            "root\nremote main\n",
+            "feat: remote main follow-up",
+        );
+        git_ok(&remote_repo, &["push", "origin", "main"]);
+
+        let output = dgr_with_input(repo, &["sync"], "n\n");
+        let stdout = strip_ansi(&String::from_utf8(output.stdout).unwrap());
+
+        assert!(output.status.success());
+        assert!(stdout.contains("Restacked:"));
+        assert!(stdout.contains("- feat/auth onto main"));
+        assert!(stdout.contains("Remote branches to update:"));
+        assert!(stdout.contains("- create feat/auth on origin"));
+        assert!(stdout.contains("Push these remote updates? [y/N]"));
+        assert!(stdout.contains("Skipped remote updates."));
+        assert_eq!(
+            git_stdout(repo, &["rev-parse", "main"]),
+            git_stdout(repo, &["rev-parse", "origin/main"])
+        );
+        assert_eq!(
+            git_stdout(repo, &["merge-base", "main", "feat/auth"]),
+            git_stdout(repo, &["rev-parse", "main"])
+        );
+        assert_eq!(git_stdout(repo, &["branch", "--show-current"]), "feat/auth");
+
+        let state = load_state_json(repo);
+        let branch = find_node(&state, "feat/auth").unwrap();
+        assert_eq!(branch["base_ref"], "main");
+        assert_eq!(branch["parent"]["kind"], "trunk");
+    });
+}
+
+#[test]
+fn sync_aborts_before_local_restack_when_trunk_pull_rebase_conflicts() {
+    with_temp_repo("dgr-sync-cli", |repo| {
+        initialize_main_repo(repo);
+        initialize_origin_remote(repo);
+        dgr_ok(repo, &["init"]);
+        dgr_ok(repo, &["branch", "feat/auth"]);
+        commit_file(repo, "auth.txt", "auth\n", "feat: auth");
+        git_ok(repo, &["checkout", "main"]);
+        overwrite_file(
+            repo,
+            "README.md",
+            "local main\n",
+            "feat: local trunk follow-up",
+        );
+
+        let remote_repo = clone_origin(repo, "origin-worktree-diverged-main");
+        git_ok(&remote_repo, &["checkout", "main"]);
+        overwrite_file(
+            &remote_repo,
+            "README.md",
+            "remote main\n",
+            "feat: remote trunk follow-up",
+        );
+        git_ok(&remote_repo, &["push", "origin", "main"]);
+        git_ok(repo, &["checkout", "feat/auth"]);
+        let feature_head_before_sync = git_stdout(repo, &["rev-parse", "feat/auth"]);
+
+        let output = dgr(repo, &["sync"]);
+        let stderr = String::from_utf8(output.stderr).unwrap();
+
+        assert!(!output.status.success());
+        assert!(stderr.contains("git pull --rebase 'origin' 'main' failed"));
+        assert_eq!(git_stdout(repo, &["branch", "--show-current"]), "feat/auth");
+        assert_eq!(
+            git_stdout(repo, &["rev-parse", "feat/auth"]),
+            feature_head_before_sync
+        );
+        assert_ne!(
+            git_stdout(repo, &["rev-parse", "main"]),
+            git_stdout(repo, &["rev-parse", "origin/main"])
+        );
+        assert!(load_operation_json(repo).is_none());
+        assert!(!repo.join(".git/rebase-merge").exists());
+        assert!(!repo.join(".git/rebase-apply").exists());
     });
 }
 
@@ -1593,7 +1677,7 @@ fn sync_continues_paused_remote_cleanup_with_stored_remote_rebase_target() {
         assert_eq!(
             operation["origin"]["current_candidate"]["kind"]["parent_base"]["new_base_ref"]
                 .as_str(),
-            Some("origin/main")
+            None
         );
 
         std::fs::write(repo.join("conflict.txt"), "resolved\n").unwrap();
@@ -1609,6 +1693,10 @@ fn sync_continues_paused_remote_cleanup_with_stored_remote_rebase_target() {
         assert!(stdout.contains("- feat/auth-ui onto main"));
         assert_eq!(
             git_stdout(repo, &["merge-base", "origin/main", "feat/auth-ui"]),
+            git_stdout(repo, &["rev-parse", "origin/main"])
+        );
+        assert_eq!(
+            git_stdout(repo, &["rev-parse", "main"]),
             git_stdout(repo, &["rev-parse", "origin/main"])
         );
 

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -106,7 +106,12 @@ fn setup_remotely_merged_root_branch_with_local_trunk_advance(repo: &Path) {
     dgr_ok(repo, &["branch", "feat/auth-ui"]);
     commit_file(repo, "ui.txt", "ui\n", "feat: ui");
     git_ok(repo, &["checkout", "main"]);
-    overwrite_file(repo, "README.md", "root\nlocal trunk\n", "feat: local trunk follow-up");
+    overwrite_file(
+        repo,
+        "README.md",
+        "root\nlocal trunk\n",
+        "feat: local trunk follow-up",
+    );
 
     let remote_repo = clone_origin(repo, "origin-worktree");
     git_ok(&remote_repo, &["checkout", "main"]);
@@ -141,7 +146,12 @@ fn setup_remotely_merged_root_branch_with_children(
     }
 
     git_ok(repo, &["checkout", "main"]);
-    overwrite_file(repo, "README.md", "root\nlocal trunk\n", "feat: local trunk follow-up");
+    overwrite_file(
+        repo,
+        "README.md",
+        "root\nlocal trunk\n",
+        "feat: local trunk follow-up",
+    );
 
     let remote_repo = clone_origin(repo, "origin-worktree");
     git_ok(&remote_repo, &["checkout", "main"]);


### PR DESCRIPTION
## Summary
Refresh sync so it updates the configured trunk branch before the existing repair, cleanup, and restack flow continues.

## What Changed
- add a sync preflight trunk refresh step that captures the original branch, switches to trunk, and runs `git pull --rebase`
- abort trunk-refresh rebase state and restore the starting branch if that preflight fails
- add a dedicated `RefreshingTrunk` sync status and render coverage
- expand sync smoke tests for trunk refresh success, preflight failure cleanup, and existing remote cleanup / PR repair flows

## Why
`sync` was restacking against stale local trunk state, which meant remote trunk updates were not consistently reflected before the normal restack plan ran.

## Validation
- `rustup run stable cargo fmt --all`
- `cargo check`
- `cargo test`
