### PR TITLE
[codex] Add branch delete restack

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ dgr pr list --view
 dgr init                        # initialize dagger in the current directory
 dgr branch <name>               # create a tracked branch from the current branch
 dgr branch <name> -p <parent>   # create a tracked branch under a specific parent
+dgr branch --delete <branch>    # delete a tracked branch and restack its children
+dgr branch -D <branch>          # alias for branch --delete
 dgr switch <branch>             # switch directly to a local branch
 dgr switch                      # choose a tracked branch from the interactive tree
 dgr tree                        # show the full tracked branch tree
@@ -160,7 +162,7 @@ When dagger creates a pull request, it prints both the creation summary and the 
 
 ### Resolve paused commands
 
-Some commands, including `dgr commit`, `dgr adopt`, `dgr reparent`, `dgr merge`, `dgr clean`, `dgr orphan`, and `dgr sync`, may pause if `dagger` hits a rebase conflict while restacking tracked descendants.
+Some commands, including `dgr commit`, `dgr adopt`, `dgr branch --delete`, `dgr reparent`, `dgr merge`, `dgr clean`, `dgr orphan`, and `dgr sync`, may pause if `dagger` hits a rebase conflict while restacking tracked descendants.
 
 When that happens:
 

--- a/src/cli/branch/mod.rs
+++ b/src/cli/branch/mod.rs
@@ -32,37 +32,54 @@ pub fn execute(args: BranchArgs) -> io::Result<CommandOutcome> {
     let options = BranchOptions::try_from(args.clone())?;
     let outcome = branch::run(&options)?;
 
-    match &outcome {
-        branch::BranchOutcome::Created(create_outcome) if create_outcome.status.success() => {
-            if let Some(node) = &create_outcome.created_node {
-                println!("Created and switched to '{}'.", node.branch_name);
-                println!();
-                println!(
-                    "{}",
-                    super::tree::render_branch_lineage(&create_outcome.lineage)
-                );
-            }
-        }
-        branch::BranchOutcome::Deleted(delete_outcome) if delete_outcome.status.success() => {
-            let rendered_tree =
-                super::tree::render_focused_context_tree(&delete_outcome.parent_branch_name, None)?;
-            let output = format_delete_success_output(delete_outcome, &rendered_tree);
-            if !output.is_empty() {
-                println!("{output}");
-            }
-        }
-        branch::BranchOutcome::Deleted(delete_outcome) if delete_outcome.paused => {
-            common::print_restack_pause_guidance(delete_outcome.failure_output.as_deref());
-        }
-        branch::BranchOutcome::Deleted(delete_outcome) => {
-            common::print_trimmed_stderr(delete_outcome.failure_output.as_deref());
-        }
-        branch::BranchOutcome::Created(_) => {}
-    }
+    print_branch_outcome(&outcome)?;
 
     Ok(CommandOutcome {
         status: outcome.status(),
     })
+}
+
+fn print_branch_outcome(outcome: &branch::BranchOutcome) -> io::Result<()> {
+    match outcome {
+        branch::BranchOutcome::Created(create_outcome) => print_create_outcome(create_outcome),
+        branch::BranchOutcome::Deleted(delete_outcome) => print_delete_outcome(delete_outcome),
+    }
+}
+
+fn print_create_outcome(outcome: &branch::CreateBranchOutcome) -> io::Result<()> {
+    if !outcome.status.success() {
+        return Ok(());
+    }
+
+    let Some(node) = &outcome.created_node else {
+        return Ok(());
+    };
+
+    println!("Created and switched to '{}'.", node.branch_name);
+    println!();
+    println!("{}", super::tree::render_branch_lineage(&outcome.lineage));
+
+    Ok(())
+}
+
+fn print_delete_outcome(outcome: &DeleteBranchOutcome) -> io::Result<()> {
+    if outcome.status.success() {
+        let rendered_tree =
+            super::tree::render_focused_context_tree(&outcome.parent_branch_name, None)?;
+        let output = format_delete_success_output(outcome, &rendered_tree);
+        if !output.is_empty() {
+            println!("{output}");
+        }
+        return Ok(());
+    }
+
+    if outcome.paused {
+        common::print_restack_pause_guidance(outcome.failure_output.as_deref());
+        return Ok(());
+    }
+
+    common::print_trimmed_stderr(outcome.failure_output.as_deref());
+    Ok(())
 }
 
 impl TryFrom<BranchArgs> for BranchOptions {
@@ -93,29 +110,29 @@ pub(crate) fn format_delete_success_output(
     outcome: &DeleteBranchOutcome,
     rendered_tree: &str,
 ) -> String {
-    let mut sections = Vec::new();
-    let mut summary_lines = vec![format!(
+    let mut sections = vec![format_delete_summary(outcome)];
+    sections.extend(
+        (!outcome.restacked_branches.is_empty())
+            .then(|| common::format_restacked_branches(&outcome.restacked_branches)),
+    );
+    sections.extend((!rendered_tree.trim().is_empty()).then(|| rendered_tree.to_string()));
+
+    common::join_sections(&sections)
+}
+
+fn format_delete_summary(outcome: &DeleteBranchOutcome) -> String {
+    let mut lines = vec![format!(
         "Deleted '{}'. It is no longer tracked by dagger.",
         outcome.branch_name
     )];
+    lines.extend(
+        outcome
+            .restored_original_branch
+            .as_ref()
+            .map(|branch| format!("Returned to '{}' after deleting.", branch)),
+    );
 
-    if let Some(original_branch) = &outcome.restored_original_branch {
-        summary_lines.push(format!("Returned to '{}' after deleting.", original_branch));
-    }
-
-    sections.push(summary_lines.join("\n"));
-
-    if !outcome.restacked_branches.is_empty() {
-        sections.push(common::format_restacked_branches(
-            &outcome.restacked_branches,
-        ));
-    }
-
-    if !rendered_tree.trim().is_empty() {
-        sections.push(rendered_tree.to_string());
-    }
-
-    common::join_sections(&sections)
+    lines.join("\n")
 }
 
 #[cfg(test)]

--- a/src/cli/branch/mod.rs
+++ b/src/cli/branch/mod.rs
@@ -2,60 +2,208 @@ use std::io;
 
 use clap::Args;
 
-use crate::core::branch::{self, BranchOptions};
+use crate::core::branch::{
+    self, BranchOptions, CreateBranchOptions, DeleteBranchOptions, DeleteBranchOutcome,
+};
 
 use super::CommandOutcome;
+use super::common;
 
 #[derive(Args, Debug, Clone)]
 pub struct BranchArgs {
-    /// The name of the branch to create from the current branch
+    /// The name of the branch to create or delete
     pub name: String,
 
+    /// Delete the tracked branch after restacking its descendants
+    #[arg(short = 'D', long = "delete", conflicts_with = "parent_branch_name")]
+    pub delete: bool,
+
     /// Override the tracked dagger parent branch
-    #[arg(short = 'p', long = "parent", value_name = "BRANCH")]
+    #[arg(
+        short = 'p',
+        long = "parent",
+        value_name = "BRANCH",
+        conflicts_with = "delete"
+    )]
     pub parent_branch_name: Option<String>,
 }
 
 pub fn execute(args: BranchArgs) -> io::Result<CommandOutcome> {
-    let outcome = branch::run(&args.clone().into())?;
+    let options = BranchOptions::try_from(args.clone())?;
+    let outcome = branch::run(&options)?;
 
-    if outcome.status.success() {
-        if let Some(node) = &outcome.created_node {
-            println!("Created and switched to '{}'.", node.branch_name);
-            println!();
-            println!("{}", super::tree::render_branch_lineage(&outcome.lineage));
+    match &outcome {
+        branch::BranchOutcome::Created(create_outcome) if create_outcome.status.success() => {
+            if let Some(node) = &create_outcome.created_node {
+                println!("Created and switched to '{}'.", node.branch_name);
+                println!();
+                println!(
+                    "{}",
+                    super::tree::render_branch_lineage(&create_outcome.lineage)
+                );
+            }
         }
+        branch::BranchOutcome::Deleted(delete_outcome) if delete_outcome.status.success() => {
+            let rendered_tree =
+                super::tree::render_focused_context_tree(&delete_outcome.parent_branch_name, None)?;
+            let output = format_delete_success_output(delete_outcome, &rendered_tree);
+            if !output.is_empty() {
+                println!("{output}");
+            }
+        }
+        branch::BranchOutcome::Deleted(delete_outcome) if delete_outcome.paused => {
+            common::print_restack_pause_guidance(delete_outcome.failure_output.as_deref());
+        }
+        branch::BranchOutcome::Deleted(delete_outcome) => {
+            common::print_trimmed_stderr(delete_outcome.failure_output.as_deref());
+        }
+        branch::BranchOutcome::Created(_) => {}
     }
 
     Ok(CommandOutcome {
-        status: outcome.status,
+        status: outcome.status(),
     })
 }
 
-impl From<BranchArgs> for BranchOptions {
-    fn from(args: BranchArgs) -> Self {
-        Self {
+impl TryFrom<BranchArgs> for BranchOptions {
+    type Error = io::Error;
+
+    fn try_from(args: BranchArgs) -> io::Result<Self> {
+        if args.delete {
+            if args.parent_branch_name.is_some() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "--parent cannot be used with --delete",
+                ));
+            }
+
+            return Ok(Self::Delete(DeleteBranchOptions {
+                branch_name: args.name,
+            }));
+        }
+
+        Ok(Self::Create(CreateBranchOptions {
             name: args.name,
             parent_branch_name: args.parent_branch_name,
-        }
+        }))
     }
+}
+
+pub(crate) fn format_delete_success_output(
+    outcome: &DeleteBranchOutcome,
+    rendered_tree: &str,
+) -> String {
+    let mut sections = Vec::new();
+    let mut summary_lines = vec![format!(
+        "Deleted '{}'. It is no longer tracked by dagger.",
+        outcome.branch_name
+    )];
+
+    if let Some(original_branch) = &outcome.restored_original_branch {
+        summary_lines.push(format!("Returned to '{}' after deleting.", original_branch));
+    }
+
+    sections.push(summary_lines.join("\n"));
+
+    if !outcome.restacked_branches.is_empty() {
+        sections.push(common::format_restacked_branches(
+            &outcome.restacked_branches,
+        ));
+    }
+
+    if !rendered_tree.trim().is_empty() {
+        sections.push(rendered_tree.to_string());
+    }
+
+    common::join_sections(&sections)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::BranchArgs;
-    use crate::core::branch::BranchOptions;
+    use super::{BranchArgs, format_delete_success_output};
+    use crate::core::branch::{
+        BranchOptions, CreateBranchOptions, DeleteBranchOptions, DeleteBranchOutcome,
+    };
+    use crate::core::git;
+    use crate::core::restack::RestackPreview;
 
     #[test]
-    fn converts_cli_args_into_core_branch_options() {
+    fn converts_create_cli_args_into_core_branch_options() {
         let args = BranchArgs {
             name: "feature/api".into(),
+            delete: false,
             parent_branch_name: Some("main".into()),
         };
 
-        let options = BranchOptions::from(args);
+        let options = BranchOptions::try_from(args).unwrap();
 
-        assert_eq!(options.name, "feature/api");
-        assert_eq!(options.parent_branch_name.as_deref(), Some("main"));
+        assert_eq!(
+            options,
+            BranchOptions::Create(CreateBranchOptions {
+                name: "feature/api".into(),
+                parent_branch_name: Some("main".into())
+            })
+        );
+    }
+
+    #[test]
+    fn converts_delete_cli_args_into_core_branch_options() {
+        let options = BranchOptions::try_from(BranchArgs {
+            name: "feature/api".into(),
+            delete: true,
+            parent_branch_name: None,
+        })
+        .unwrap();
+
+        assert_eq!(
+            options,
+            BranchOptions::Delete(DeleteBranchOptions {
+                branch_name: "feature/api".into()
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_delete_with_parent_override() {
+        let err = BranchOptions::try_from(BranchArgs {
+            name: "feature/api".into(),
+            delete: true,
+            parent_branch_name: Some("main".into()),
+        })
+        .unwrap_err();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn formats_delete_success_output_with_restacked_branches() {
+        let output = format_delete_success_output(
+            &DeleteBranchOutcome {
+                status: git::success_status().unwrap(),
+                branch_name: "feat/auth".into(),
+                parent_branch_name: "main".into(),
+                restacked_branches: vec![RestackPreview {
+                    branch_name: "feat/auth-ui".into(),
+                    onto_branch: "main".into(),
+                    parent_changed: true,
+                }],
+                restored_original_branch: Some("main".into()),
+                failure_output: None,
+                paused: false,
+            },
+            "main\n└── feat/auth-ui",
+        );
+
+        assert_eq!(
+            output,
+            concat!(
+                "Deleted 'feat/auth'. It is no longer tracked by dagger.\n",
+                "Returned to 'main' after deleting.\n\n",
+                "Restacked:\n",
+                "- feat/auth-ui onto main\n\n",
+                "main\n",
+                "└── feat/auth-ui"
+            )
+        );
     }
 }

--- a/src/cli/sync/mod.rs
+++ b/src/cli/sync/mod.rs
@@ -62,6 +62,17 @@ pub fn execute(args: SyncArgs) -> io::Result<CommandOutcome> {
                     println!("{output}");
                 }
             }
+            SyncCompletion::BranchDelete(delete_outcome) if delete_outcome.status.success() => {
+                let rendered_tree = super::tree::render_focused_context_tree(
+                    &delete_outcome.parent_branch_name,
+                    None,
+                )?;
+                let output =
+                    super::branch::format_delete_success_output(delete_outcome, &rendered_tree);
+                if !output.is_empty() {
+                    println!("{output}");
+                }
+            }
             SyncCompletion::Merge(merge_outcome) if merge_outcome.outcome.status.success() => {
                 let deleted_branch_name = if super::merge::confirm_delete_merged_branch(
                     &merge_outcome.source_branch_name,

--- a/src/core/branch.rs
+++ b/src/core/branch.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use crate::core::git;
 use crate::core::graph::BranchGraph;
 use crate::core::graph::BranchLineageNode;
-use crate::core::restack::{self, RestackPreview};
+use crate::core::restack::{self, RestackAction, RestackPreview};
 use crate::core::store::types::DaggerState;
 use crate::core::store::{
     BranchArchiveReason, BranchDivergenceState, BranchNode, DaggerConfig, ParentRef,
@@ -64,6 +64,52 @@ pub struct DeleteBranchOutcome {
     pub restored_original_branch: Option<String>,
     pub failure_output: Option<String>,
     pub paused: bool,
+}
+
+impl DeleteBranchOutcome {
+    fn paused(
+        completion: PendingBranchDeleteOperation,
+        restack_outcome: workflow::ResumableRestackExecutionOutcome,
+    ) -> Self {
+        Self {
+            status: restack_outcome.status,
+            branch_name: completion.branch_name,
+            parent_branch_name: completion.parent_branch_name,
+            restacked_branches: restack_outcome.restacked_branches,
+            restored_original_branch: None,
+            failure_output: restack_outcome.failure_output,
+            paused: true,
+        }
+    }
+
+    fn delete_failed(
+        completion: &PendingBranchDeleteOperation,
+        status: ExitStatus,
+        restacked_branches: Vec<RestackPreview>,
+    ) -> Self {
+        Self {
+            status,
+            branch_name: completion.branch_name.clone(),
+            parent_branch_name: completion.parent_branch_name.clone(),
+            restacked_branches,
+            restored_original_branch: None,
+            failure_output: None,
+            paused: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct DeleteBranchPlan {
+    completion: PendingBranchDeleteOperation,
+    restack_actions: Vec<RestackAction>,
+}
+
+#[derive(Debug)]
+struct RestoreOriginalBranchOutcome {
+    status: ExitStatus,
+    restored_original_branch: Option<String>,
+    failure_output: Option<String>,
 }
 
 pub fn run(options: &BranchOptions) -> io::Result<BranchOutcome> {
@@ -159,119 +205,20 @@ fn create_branch(options: &CreateBranchOptions) -> io::Result<CreateBranchOutcom
 
 fn delete_branch(options: &DeleteBranchOptions) -> io::Result<DeleteBranchOutcome> {
     workflow::ensure_no_pending_operation_for_command("branch")?;
-    let branch_name = resolve_delete_branch_name(&options.branch_name)?;
     let original_branch = git::current_branch_name()?;
     let mut session = open_initialized("dagger is not initialized; run 'dgr init' first")?;
     workflow::ensure_ready_for_operation(&session.repo, "branch")?;
     workflow::ensure_no_pending_operation(&session.paths, "branch")?;
 
-    if branch_name == session.config.trunk_branch {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!(
-                "cannot delete trunk branch '{}'",
-                session.config.trunk_branch
-            ),
-        ));
-    }
-
-    if !git::branch_exists(&branch_name)? {
-        return Err(io::Error::new(
-            io::ErrorKind::NotFound,
-            format!("branch '{}' does not exist", branch_name),
-        ));
-    }
-
-    let node = session
-        .state
-        .find_branch_by_name(&branch_name)
-        .cloned()
-        .ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::NotFound,
-                format!("branch '{}' is not tracked by dagger", branch_name),
-            )
-        })?;
-
-    if branch_name == original_branch {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!(
-                "cannot delete checked-out branch '{}'; switch to another branch first",
-                branch_name
-            ),
-        ));
-    }
-
-    let graph = BranchGraph::new(&session.state);
-    let parent_branch_name = graph
-        .parent_branch_name(&node, &session.config.trunk_branch)
-        .ok_or_else(|| {
-            io::Error::other(format!(
-                "tracked parent for '{}' is missing from dagger",
-                branch_name
-            ))
-        })?;
-
-    if !git::branch_exists(&parent_branch_name)? {
-        return Err(io::Error::new(
-            io::ErrorKind::NotFound,
-            format!("parent branch '{}' does not exist", parent_branch_name),
-        ));
-    }
-
-    let missing_descendants = graph.missing_local_descendants(node.id)?;
-    if !missing_descendants.is_empty() {
-        return Err(io::Error::new(
-            io::ErrorKind::NotFound,
-            format!(
-                "tracked descendants of '{}' are missing locally: {}",
-                branch_name,
-                missing_descendants.join(", ")
-            ),
-        ));
-    }
-
-    let restack_actions = restack::plan_after_branch_detach(
-        &session.state,
-        node.id,
-        &node.branch_name,
-        &restack::RestackBaseTarget::local(&parent_branch_name),
-        &node.parent,
-    )?;
+    let plan = plan_delete_branch(&session, original_branch, &options.branch_name)?;
     let restack_outcome = workflow::execute_resumable_restack_operation(
         &mut session,
-        PendingOperationKind::BranchDelete(PendingBranchDeleteOperation {
-            original_branch: original_branch.clone(),
-            branch_name: branch_name.clone(),
-            parent_branch_name: parent_branch_name.clone(),
-            node_id: node.id,
-        }),
-        &restack_actions,
+        PendingOperationKind::BranchDelete(plan.completion.clone()),
+        &plan.restack_actions,
         &mut |_| Ok(()),
     )?;
 
-    if restack_outcome.paused {
-        return Ok(DeleteBranchOutcome {
-            status: restack_outcome.status,
-            branch_name,
-            parent_branch_name,
-            restacked_branches: restack_outcome.restacked_branches,
-            restored_original_branch: None,
-            failure_output: restack_outcome.failure_output,
-            paused: true,
-        });
-    }
-
-    complete_delete(
-        &mut session,
-        node.id,
-        &branch_name,
-        &parent_branch_name,
-        &original_branch,
-        restack_outcome.restacked_branches,
-        restack_outcome.status,
-    )
+    complete_or_pause_delete(&mut session, plan.completion, restack_outcome)
 }
 
 pub(crate) fn resume_delete_after_sync(
@@ -285,24 +232,61 @@ pub(crate) fn resume_delete_after_sync(
         &mut |_| Ok(()),
     )?;
 
+    complete_or_pause_delete(&mut session, payload, restack_outcome)
+}
+
+fn plan_delete_branch(
+    session: &StoreSession,
+    original_branch: String,
+    requested_branch_name: &str,
+) -> io::Result<DeleteBranchPlan> {
+    let branch_name = resolve_delete_branch_name(requested_branch_name)?;
+    ensure_branch_is_not_trunk(&branch_name, &session.config.trunk_branch)?;
+    ensure_local_branch_exists(
+        &branch_name,
+        format!("branch '{}' does not exist", branch_name),
+    )?;
+    ensure_branch_is_not_current(&branch_name, &original_branch)?;
+
+    let node = load_tracked_branch_by_name(&session.state, &branch_name)?;
+    let parent_branch_name =
+        resolve_tracked_parent_branch_name(&session.state, &session.config.trunk_branch, &node)?;
+
+    ensure_local_branch_exists(
+        &parent_branch_name,
+        format!("parent branch '{}' does not exist", parent_branch_name),
+    )?;
+    ensure_local_descendants_exist(&session.state, node.id, &branch_name)?;
+
+    Ok(DeleteBranchPlan {
+        completion: PendingBranchDeleteOperation {
+            original_branch,
+            branch_name,
+            parent_branch_name: parent_branch_name.clone(),
+            node_id: node.id,
+        },
+        restack_actions: restack::plan_after_branch_detach(
+            &session.state,
+            node.id,
+            &node.branch_name,
+            &restack::RestackBaseTarget::local(parent_branch_name),
+            &node.parent,
+        )?,
+    })
+}
+
+fn complete_or_pause_delete(
+    session: &mut StoreSession,
+    completion: PendingBranchDeleteOperation,
+    restack_outcome: workflow::ResumableRestackExecutionOutcome,
+) -> io::Result<DeleteBranchOutcome> {
     if restack_outcome.paused {
-        return Ok(DeleteBranchOutcome {
-            status: restack_outcome.status,
-            branch_name: payload.branch_name,
-            parent_branch_name: payload.parent_branch_name,
-            restacked_branches: restack_outcome.restacked_branches,
-            restored_original_branch: None,
-            failure_output: restack_outcome.failure_output,
-            paused: true,
-        });
+        return Ok(DeleteBranchOutcome::paused(completion, restack_outcome));
     }
 
     complete_delete(
-        &mut session,
-        payload.node_id,
-        &payload.branch_name,
-        &payload.parent_branch_name,
-        &payload.original_branch,
+        session,
+        &completion,
         restack_outcome.restacked_branches,
         restack_outcome.status,
     )
@@ -310,30 +294,19 @@ pub(crate) fn resume_delete_after_sync(
 
 fn complete_delete(
     session: &mut StoreSession,
-    node_id: Uuid,
-    branch_name: &str,
-    parent_branch_name: &str,
-    original_branch: &str,
+    completion: &PendingBranchDeleteOperation,
     restacked_branches: Vec<RestackPreview>,
     restack_status: ExitStatus,
 ) -> io::Result<DeleteBranchOutcome> {
-    let node = session
-        .state
-        .find_branch_by_id(node_id)
-        .cloned()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "tracked branch was not found"))?;
+    let node = load_tracked_branch_by_id(&session.state, completion.node_id)?;
 
     let delete_status = git::delete_branch_force(&node.branch_name)?;
     if !delete_status.success() {
-        return Ok(DeleteBranchOutcome {
-            status: delete_status,
-            branch_name: branch_name.to_string(),
-            parent_branch_name: parent_branch_name.to_string(),
+        return Ok(DeleteBranchOutcome::delete_failed(
+            completion,
+            delete_status,
             restacked_branches,
-            restored_original_branch: None,
-            failure_output: None,
-            paused: false,
-        });
+        ));
     }
 
     record_branch_archived(
@@ -343,32 +316,132 @@ fn complete_delete(
         BranchArchiveReason::DeletedByUser,
     )?;
 
-    let mut final_status = restack_status;
-    let mut restored_original_branch = None;
-    let mut failure_output = None;
-
-    if let Some(outcome) = workflow::restore_original_branch_if_needed(original_branch)? {
-        if outcome.status.success() {
-            restored_original_branch = Some(outcome.restored_branch);
-            final_status = outcome.status;
-        } else {
-            final_status = outcome.status;
-            failure_output = Some(format!(
-                "branch deleted, but failed to return to '{}'",
-                original_branch
-            ));
-        }
-    }
+    let restore_outcome =
+        restore_original_branch_after_delete(&completion.original_branch, restack_status)?;
 
     Ok(DeleteBranchOutcome {
-        status: final_status,
-        branch_name: branch_name.to_string(),
-        parent_branch_name: parent_branch_name.to_string(),
+        status: restore_outcome.status,
+        branch_name: completion.branch_name.clone(),
+        parent_branch_name: completion.parent_branch_name.clone(),
         restacked_branches,
-        restored_original_branch,
-        failure_output,
+        restored_original_branch: restore_outcome.restored_original_branch,
+        failure_output: restore_outcome.failure_output,
         paused: false,
     })
+}
+
+fn restore_original_branch_after_delete(
+    original_branch: &str,
+    default_status: ExitStatus,
+) -> io::Result<RestoreOriginalBranchOutcome> {
+    let Some(outcome) = workflow::restore_original_branch_if_needed(original_branch)? else {
+        return Ok(RestoreOriginalBranchOutcome {
+            status: default_status,
+            restored_original_branch: None,
+            failure_output: None,
+        });
+    };
+
+    if !outcome.status.success() {
+        return Ok(RestoreOriginalBranchOutcome {
+            status: outcome.status,
+            restored_original_branch: None,
+            failure_output: Some(format!(
+                "branch deleted, but failed to return to '{}'",
+                original_branch
+            )),
+        });
+    }
+
+    Ok(RestoreOriginalBranchOutcome {
+        status: outcome.status,
+        restored_original_branch: Some(outcome.restored_branch),
+        failure_output: None,
+    })
+}
+
+fn ensure_branch_is_not_trunk(branch_name: &str, trunk_branch: &str) -> io::Result<()> {
+    if branch_name != trunk_branch {
+        return Ok(());
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!("cannot delete trunk branch '{}'", trunk_branch),
+    ))
+}
+
+fn ensure_branch_is_not_current(branch_name: &str, current_branch: &str) -> io::Result<()> {
+    if branch_name != current_branch {
+        return Ok(());
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!("cannot delete checked-out branch '{branch_name}'; switch to another branch first"),
+    ))
+}
+
+fn ensure_local_branch_exists(branch_name: &str, not_found_message: String) -> io::Result<()> {
+    if git::branch_exists(branch_name)? {
+        return Ok(());
+    }
+
+    Err(io::Error::new(io::ErrorKind::NotFound, not_found_message))
+}
+
+fn ensure_local_descendants_exist(
+    state: &DaggerState,
+    node_id: Uuid,
+    branch_name: &str,
+) -> io::Result<()> {
+    let missing_descendants = BranchGraph::new(state).missing_local_descendants(node_id)?;
+    if missing_descendants.is_empty() {
+        return Ok(());
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        format!(
+            "tracked descendants of '{}' are missing locally: {}",
+            branch_name,
+            missing_descendants.join(", ")
+        ),
+    ))
+}
+
+fn load_tracked_branch_by_name(state: &DaggerState, branch_name: &str) -> io::Result<BranchNode> {
+    state
+        .find_branch_by_name(branch_name)
+        .cloned()
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("branch '{}' is not tracked by dagger", branch_name),
+            )
+        })
+}
+
+fn load_tracked_branch_by_id(state: &DaggerState, node_id: Uuid) -> io::Result<BranchNode> {
+    state
+        .find_branch_by_id(node_id)
+        .cloned()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "tracked branch was not found"))
+}
+
+fn resolve_tracked_parent_branch_name(
+    state: &DaggerState,
+    trunk_branch: &str,
+    node: &BranchNode,
+) -> io::Result<String> {
+    BranchGraph::new(state)
+        .parent_branch_name(node, trunk_branch)
+        .ok_or_else(|| {
+            io::Error::other(format!(
+                "tracked parent for '{}' is missing from dagger",
+                node.branch_name
+            ))
+        })
 }
 
 fn resolve_delete_branch_name(requested_branch_name: &str) -> io::Result<String> {

--- a/src/core/branch.rs
+++ b/src/core/branch.rs
@@ -6,26 +6,74 @@ use uuid::Uuid;
 use crate::core::git;
 use crate::core::graph::BranchGraph;
 use crate::core::graph::BranchLineageNode;
+use crate::core::restack::{self, RestackPreview};
 use crate::core::store::types::DaggerState;
 use crate::core::store::{
-    BranchDivergenceState, BranchNode, DaggerConfig, ParentRef, now_unix_timestamp_secs,
-    open_or_initialize, record_branch_created,
+    BranchArchiveReason, BranchDivergenceState, BranchNode, DaggerConfig, ParentRef,
+    PendingBranchDeleteOperation, PendingOperationKind, PendingOperationState, StoreSession,
+    now_unix_timestamp_secs, open_initialized, open_or_initialize, record_branch_archived,
+    record_branch_created,
 };
+use crate::core::workflow;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BranchOptions {
+pub enum BranchOptions {
+    Create(CreateBranchOptions),
+    Delete(DeleteBranchOptions),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateBranchOptions {
     pub name: String,
     pub parent_branch_name: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeleteBranchOptions {
+    pub branch_name: String,
+}
+
 #[derive(Debug, Clone)]
-pub struct BranchOutcome {
+pub enum BranchOutcome {
+    Created(CreateBranchOutcome),
+    Deleted(DeleteBranchOutcome),
+}
+
+impl BranchOutcome {
+    pub fn status(&self) -> ExitStatus {
+        match self {
+            Self::Created(outcome) => outcome.status,
+            Self::Deleted(outcome) => outcome.status,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateBranchOutcome {
     pub status: ExitStatus,
     pub created_node: Option<BranchNode>,
     pub lineage: Vec<BranchLineageNode>,
 }
 
+#[derive(Debug, Clone)]
+pub struct DeleteBranchOutcome {
+    pub status: ExitStatus,
+    pub branch_name: String,
+    pub parent_branch_name: String,
+    pub restacked_branches: Vec<RestackPreview>,
+    pub restored_original_branch: Option<String>,
+    pub failure_output: Option<String>,
+    pub paused: bool,
+}
+
 pub fn run(options: &BranchOptions) -> io::Result<BranchOutcome> {
+    match options {
+        BranchOptions::Create(options) => create_branch(options).map(BranchOutcome::Created),
+        BranchOptions::Delete(options) => delete_branch(options).map(BranchOutcome::Deleted),
+    }
+}
+
+fn create_branch(options: &CreateBranchOptions) -> io::Result<CreateBranchOutcome> {
     let branch_name = options.name.trim();
     if branch_name.is_empty() {
         return Err(io::Error::new(
@@ -89,7 +137,7 @@ pub fn run(options: &BranchOptions) -> io::Result<BranchOutcome> {
     let status = git::create_and_checkout_branch(branch_name, &parent_branch_name)?;
 
     if !status.success() {
-        return Ok(BranchOutcome {
+        return Ok(CreateBranchOutcome {
             status,
             created_node: None,
             lineage: vec![BranchLineageNode {
@@ -102,11 +150,238 @@ pub fn run(options: &BranchOptions) -> io::Result<BranchOutcome> {
     record_branch_created(&mut session, created_node.clone())?;
     let graph = BranchGraph::new(&session.state);
 
-    Ok(BranchOutcome {
+    Ok(CreateBranchOutcome {
         status,
         created_node: Some(created_node),
         lineage: graph.lineage(branch_name, &session.config.trunk_branch),
     })
+}
+
+fn delete_branch(options: &DeleteBranchOptions) -> io::Result<DeleteBranchOutcome> {
+    workflow::ensure_no_pending_operation_for_command("branch")?;
+    let branch_name = resolve_delete_branch_name(&options.branch_name)?;
+    let original_branch = git::current_branch_name()?;
+    let mut session = open_initialized("dagger is not initialized; run 'dgr init' first")?;
+    workflow::ensure_ready_for_operation(&session.repo, "branch")?;
+    workflow::ensure_no_pending_operation(&session.paths, "branch")?;
+
+    if branch_name == session.config.trunk_branch {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "cannot delete trunk branch '{}'",
+                session.config.trunk_branch
+            ),
+        ));
+    }
+
+    if !git::branch_exists(&branch_name)? {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("branch '{}' does not exist", branch_name),
+        ));
+    }
+
+    let node = session
+        .state
+        .find_branch_by_name(&branch_name)
+        .cloned()
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("branch '{}' is not tracked by dagger", branch_name),
+            )
+        })?;
+
+    if branch_name == original_branch {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "cannot delete checked-out branch '{}'; switch to another branch first",
+                branch_name
+            ),
+        ));
+    }
+
+    let graph = BranchGraph::new(&session.state);
+    let parent_branch_name = graph
+        .parent_branch_name(&node, &session.config.trunk_branch)
+        .ok_or_else(|| {
+            io::Error::other(format!(
+                "tracked parent for '{}' is missing from dagger",
+                branch_name
+            ))
+        })?;
+
+    if !git::branch_exists(&parent_branch_name)? {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("parent branch '{}' does not exist", parent_branch_name),
+        ));
+    }
+
+    let missing_descendants = graph.missing_local_descendants(node.id)?;
+    if !missing_descendants.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!(
+                "tracked descendants of '{}' are missing locally: {}",
+                branch_name,
+                missing_descendants.join(", ")
+            ),
+        ));
+    }
+
+    let restack_actions = restack::plan_after_branch_detach(
+        &session.state,
+        node.id,
+        &node.branch_name,
+        &restack::RestackBaseTarget::local(&parent_branch_name),
+        &node.parent,
+    )?;
+    let restack_outcome = workflow::execute_resumable_restack_operation(
+        &mut session,
+        PendingOperationKind::BranchDelete(PendingBranchDeleteOperation {
+            original_branch: original_branch.clone(),
+            branch_name: branch_name.clone(),
+            parent_branch_name: parent_branch_name.clone(),
+            node_id: node.id,
+        }),
+        &restack_actions,
+        &mut |_| Ok(()),
+    )?;
+
+    if restack_outcome.paused {
+        return Ok(DeleteBranchOutcome {
+            status: restack_outcome.status,
+            branch_name,
+            parent_branch_name,
+            restacked_branches: restack_outcome.restacked_branches,
+            restored_original_branch: None,
+            failure_output: restack_outcome.failure_output,
+            paused: true,
+        });
+    }
+
+    complete_delete(
+        &mut session,
+        node.id,
+        &branch_name,
+        &parent_branch_name,
+        &original_branch,
+        restack_outcome.restacked_branches,
+        restack_outcome.status,
+    )
+}
+
+pub(crate) fn resume_delete_after_sync(
+    pending_operation: PendingOperationState,
+    payload: PendingBranchDeleteOperation,
+) -> io::Result<DeleteBranchOutcome> {
+    let mut session = open_initialized("dagger is not initialized; run 'dgr init' first")?;
+    let restack_outcome = workflow::continue_resumable_restack_operation(
+        &mut session,
+        pending_operation,
+        &mut |_| Ok(()),
+    )?;
+
+    if restack_outcome.paused {
+        return Ok(DeleteBranchOutcome {
+            status: restack_outcome.status,
+            branch_name: payload.branch_name,
+            parent_branch_name: payload.parent_branch_name,
+            restacked_branches: restack_outcome.restacked_branches,
+            restored_original_branch: None,
+            failure_output: restack_outcome.failure_output,
+            paused: true,
+        });
+    }
+
+    complete_delete(
+        &mut session,
+        payload.node_id,
+        &payload.branch_name,
+        &payload.parent_branch_name,
+        &payload.original_branch,
+        restack_outcome.restacked_branches,
+        restack_outcome.status,
+    )
+}
+
+fn complete_delete(
+    session: &mut StoreSession,
+    node_id: Uuid,
+    branch_name: &str,
+    parent_branch_name: &str,
+    original_branch: &str,
+    restacked_branches: Vec<RestackPreview>,
+    restack_status: ExitStatus,
+) -> io::Result<DeleteBranchOutcome> {
+    let node = session
+        .state
+        .find_branch_by_id(node_id)
+        .cloned()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "tracked branch was not found"))?;
+
+    let delete_status = git::delete_branch_force(&node.branch_name)?;
+    if !delete_status.success() {
+        return Ok(DeleteBranchOutcome {
+            status: delete_status,
+            branch_name: branch_name.to_string(),
+            parent_branch_name: parent_branch_name.to_string(),
+            restacked_branches,
+            restored_original_branch: None,
+            failure_output: None,
+            paused: false,
+        });
+    }
+
+    record_branch_archived(
+        session,
+        node.id,
+        node.branch_name,
+        BranchArchiveReason::DeletedByUser,
+    )?;
+
+    let mut final_status = restack_status;
+    let mut restored_original_branch = None;
+    let mut failure_output = None;
+
+    if let Some(outcome) = workflow::restore_original_branch_if_needed(original_branch)? {
+        if outcome.status.success() {
+            restored_original_branch = Some(outcome.restored_branch);
+            final_status = outcome.status;
+        } else {
+            final_status = outcome.status;
+            failure_output = Some(format!(
+                "branch deleted, but failed to return to '{}'",
+                original_branch
+            ));
+        }
+    }
+
+    Ok(DeleteBranchOutcome {
+        status: final_status,
+        branch_name: branch_name.to_string(),
+        parent_branch_name: parent_branch_name.to_string(),
+        restacked_branches,
+        restored_original_branch,
+        failure_output,
+        paused: false,
+    })
+}
+
+fn resolve_delete_branch_name(requested_branch_name: &str) -> io::Result<String> {
+    let branch_name = requested_branch_name.trim();
+
+    if branch_name.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "branch name cannot be empty",
+        ));
+    }
+
+    Ok(branch_name.to_string())
 }
 
 fn resolve_parent_branch_name(
@@ -150,19 +425,47 @@ pub(crate) fn resolve_parent_ref(
 
 #[cfg(test)]
 mod tests {
-    use super::{BranchOptions, resolve_parent_branch_name, resolve_parent_ref};
+    use super::{
+        BranchOptions, CreateBranchOptions, DeleteBranchOptions, resolve_delete_branch_name,
+        resolve_parent_branch_name, resolve_parent_ref,
+    };
     use crate::core::store::types::DaggerState;
     use crate::core::store::{BranchDivergenceState, BranchNode, DaggerConfig, ParentRef};
     use uuid::Uuid;
 
     #[test]
-    fn preserves_requested_branch_name() {
-        let options = BranchOptions {
+    fn preserves_create_branch_options() {
+        let options = BranchOptions::Create(CreateBranchOptions {
             name: "feature/api".into(),
             parent_branch_name: None,
-        };
+        });
 
-        assert_eq!(options.name, "feature/api");
+        assert_eq!(
+            options,
+            BranchOptions::Create(CreateBranchOptions {
+                name: "feature/api".into(),
+                parent_branch_name: None,
+            })
+        );
+    }
+
+    #[test]
+    fn preserves_delete_branch_options() {
+        let options = BranchOptions::Delete(DeleteBranchOptions {
+            branch_name: "feature/api".into(),
+        });
+
+        assert_eq!(
+            options,
+            BranchOptions::Delete(DeleteBranchOptions {
+                branch_name: "feature/api".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_blank_delete_branch_name() {
+        assert!(resolve_delete_branch_name(" ").is_err());
     }
 
     #[test]

--- a/src/core/store/mod.rs
+++ b/src/core/store/mod.rs
@@ -23,8 +23,9 @@ pub(crate) use types::{
     BranchAdoptedEvent, BranchArchiveReason, BranchArchivedEvent, BranchCreatedEvent,
     BranchDivergenceState, BranchNode, BranchPullRequestTrackedEvent,
     BranchPullRequestTrackedSource, BranchReparentedEvent, DaggerConfig, DaggerEvent, ParentRef,
-    PendingAdoptOperation, PendingCleanCandidate, PendingCleanCandidateKind, PendingCleanOperation,
-    PendingCommitEntry, PendingCommitOperation, PendingMergeOperation, PendingOperationKind,
-    PendingOperationState, PendingOrphanOperation, PendingReparentOperation, PendingSyncOperation,
-    PendingSyncPhase, TrackedPullRequest, now_unix_timestamp_secs,
+    PendingAdoptOperation, PendingBranchDeleteOperation, PendingCleanCandidate,
+    PendingCleanCandidateKind, PendingCleanOperation, PendingCommitEntry, PendingCommitOperation,
+    PendingMergeOperation, PendingOperationKind, PendingOperationState, PendingOrphanOperation,
+    PendingReparentOperation, PendingSyncOperation, PendingSyncPhase, TrackedPullRequest,
+    now_unix_timestamp_secs,
 };

--- a/src/core/store/types.rs
+++ b/src/core/store/types.rs
@@ -197,6 +197,7 @@ pub struct PendingRestackState {
 pub enum PendingOperationKind {
     Commit(PendingCommitOperation),
     Adopt(PendingAdoptOperation),
+    BranchDelete(PendingBranchDeleteOperation),
     Merge(PendingMergeOperation),
     Clean(PendingCleanOperation),
     Orphan(PendingOrphanOperation),
@@ -209,6 +210,7 @@ impl PendingOperationKind {
         match self {
             Self::Commit(_) => "commit",
             Self::Adopt(_) => "adopt",
+            Self::BranchDelete(_) => "branch",
             Self::Merge(_) => "merge",
             Self::Clean(_) => "clean",
             Self::Orphan(_) => "orphan",
@@ -231,6 +233,14 @@ pub struct PendingAdoptOperation {
     pub branch_name: String,
     pub parent_branch_name: String,
     pub parent: ParentRef,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingBranchDeleteOperation {
+    pub original_branch: String,
+    pub branch_name: String,
+    pub parent_branch_name: String,
+    pub node_id: Uuid,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -374,6 +384,7 @@ pub enum BranchArchiveReason {
     IntegratedIntoParent { parent_branch: String },
     Orphaned,
     DeletedLocally,
+    DeletedByUser,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -423,9 +434,9 @@ mod tests {
     use super::{
         BranchAdoptedEvent, BranchArchiveReason, BranchArchivedEvent, BranchDivergenceState,
         BranchNode, BranchPullRequestTrackedEvent, BranchPullRequestTrackedSource, DaggerConfig,
-        DaggerEvent, DaggerState, ParentRef, PendingCommitOperation, PendingOperationKind,
-        PendingOperationState, PendingOrphanOperation, PendingReparentOperation,
-        PendingSyncOperation, PendingSyncPhase, TrackedPullRequest,
+        DaggerEvent, DaggerState, ParentRef, PendingBranchDeleteOperation, PendingCommitOperation,
+        PendingOperationKind, PendingOperationState, PendingOrphanOperation,
+        PendingReparentOperation, PendingSyncOperation, PendingSyncPhase, TrackedPullRequest,
     };
     use crate::core::restack::{RestackAction, RestackBaseTarget};
     use uuid::Uuid;
@@ -628,6 +639,18 @@ mod tests {
     }
 
     #[test]
+    fn reports_branch_delete_operation_command_name() {
+        let operation = PendingOperationKind::BranchDelete(PendingBranchDeleteOperation {
+            original_branch: "main".into(),
+            branch_name: "feature/api".into(),
+            parent_branch_name: "main".into(),
+            node_id: Uuid::nil(),
+        });
+
+        assert_eq!(operation.command_name(), "branch");
+    }
+
+    #[test]
     fn reports_sync_operation_command_name() {
         let operation = PendingOperationKind::Sync(PendingSyncOperation {
             original_branch: "feature/api".into(),
@@ -665,5 +688,20 @@ mod tests {
 
         assert!(serialized.contains("\"type\":\"branch_archived\""));
         assert!(serialized.contains("\"kind\":\"deleted_locally\""));
+    }
+
+    #[test]
+    fn serializes_deleted_by_user_branch_archive_event() {
+        let event = DaggerEvent::BranchArchived(BranchArchivedEvent {
+            occurred_at_unix_secs: 1,
+            branch_id: Uuid::nil(),
+            branch_name: "feature/api".into(),
+            reason: BranchArchiveReason::DeletedByUser,
+        });
+
+        let serialized = serde_json::to_string(&event).unwrap();
+
+        assert!(serialized.contains("\"type\":\"branch_archived\""));
+        assert!(serialized.contains("\"kind\":\"deleted_by_user\""));
     }
 }

--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -13,7 +13,7 @@ use crate::core::store::{
     PendingSyncPhase, clear_operation, load_operation, open_initialized,
 };
 use crate::core::workflow;
-use crate::core::{adopt, commit, git, merge, orphan, reparent};
+use crate::core::{adopt, branch, commit, git, merge, orphan, reparent};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SyncOptions {
@@ -99,6 +99,7 @@ pub enum SyncEvent {
 pub enum SyncCompletion {
     Commit(commit::CommitOutcome),
     Adopt(adopt::AdoptOutcome),
+    BranchDelete(branch::DeleteBranchOutcome),
     Merge(merge::MergeResumeOutcome),
     Clean {
         trunk_branch: String,
@@ -266,6 +267,23 @@ where
             Ok(SyncOutcome {
                 status,
                 completion: Some(SyncCompletion::Adopt(outcome)),
+                failure_output,
+                paused,
+            })
+        }
+        PendingOperationKind::BranchDelete(payload) => {
+            let continue_output = git::continue_rebase()?;
+            if !continue_output.status.success() {
+                return Ok(paused_continue_outcome(continue_output));
+            }
+
+            let outcome = branch::resume_delete_after_sync(pending_operation, payload)?;
+            let status = outcome.status;
+            let failure_output = outcome.failure_output.clone();
+            let paused = outcome.paused;
+            Ok(SyncOutcome {
+                status,
+                completion: Some(SyncCompletion::BranchDelete(outcome)),
                 failure_output,
                 paused,
             })

--- a/src/core/test_support.rs
+++ b/src/core/test_support.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::process::Command;
 use std::sync::MutexGuard;
 
-use crate::core::branch::{self, BranchOptions};
+use crate::core::branch::{self, BranchOptions, CreateBranchOptions};
 
 pub(crate) fn with_temp_repo(prefix: &str, test: impl FnOnce(&Path)) {
     let guard: MutexGuard<'_, ()> = crate::core::test_cwd_lock().lock().unwrap();
@@ -37,10 +37,10 @@ pub(crate) fn initialize_main_repo(repo: &Path) {
 }
 
 pub(crate) fn create_tracked_branch(branch_name: &str) {
-    branch::run(&BranchOptions {
+    branch::run(&BranchOptions::Create(CreateBranchOptions {
         name: branch_name.into(),
         parent_branch_name: None,
-    })
+    }))
     .unwrap();
 }
 

--- a/tests/branch.rs
+++ b/tests/branch.rs
@@ -3,8 +3,10 @@ mod support;
 use std::path::{Path, PathBuf};
 
 use support::{
-    dgr_ok, dgr_ok_with_env, find_node, initialize_main_repo, install_fake_executable,
-    load_state_json, path_with_prepend, strip_ansi, with_temp_repo,
+    active_rebase_head_name, commit_file, dgr, dgr_ok, dgr_ok_with_env, find_archived_node,
+    find_node, git_ok, git_stdout, initialize_main_repo, install_fake_executable, load_events_json,
+    load_operation_json, load_state_json, path_with_prepend, strip_ansi, with_temp_repo,
+    write_file,
 };
 
 fn install_fake_gh(repo: &Path, script: &str) -> (PathBuf, String) {
@@ -81,5 +83,199 @@ exit 1
         let stdout = strip_ansi(&String::from_utf8(output.stdout).unwrap());
 
         assert!(stdout.contains("✓ feat/auth (#123)\n│ \n* main"));
+    });
+}
+
+#[test]
+fn branch_delete_removes_leaf_branch_and_archives_it() {
+    with_temp_repo("dgr-branch-cli", |repo| {
+        initialize_main_repo(repo);
+        dgr_ok(repo, &["init"]);
+        dgr_ok(repo, &["branch", "feat/auth"]);
+        commit_file(repo, "auth.txt", "auth\n", "feat: auth");
+        git_ok(repo, &["checkout", "main"]);
+
+        let output = dgr_ok(repo, &["branch", "-D", "feat/auth"]);
+        let stdout = strip_ansi(&String::from_utf8(output.stdout).unwrap());
+
+        assert!(stdout.contains("Deleted 'feat/auth'. It is no longer tracked by dagger."));
+        assert!(!git_stdout(repo, &["branch", "--list", "feat/auth"]).contains("feat/auth"));
+        assert_eq!(git_stdout(repo, &["branch", "--show-current"]), "main");
+
+        let state = load_state_json(repo);
+        assert!(find_node(&state, "feat/auth").is_none());
+        let archived = find_archived_node(&state, "feat/auth").unwrap();
+        assert_eq!(archived["archived"], true);
+        let events = load_events_json(repo);
+        assert!(events.iter().any(|event| {
+            event["type"].as_str() == Some("branch_archived")
+                && event["branch_name"].as_str() == Some("feat/auth")
+                && event["reason"]["kind"].as_str() == Some("deleted_by_user")
+        }));
+        assert_eq!(load_operation_json(repo), None);
+    });
+}
+
+#[test]
+fn branch_delete_restacks_child_onto_deleted_branch_parent() {
+    with_temp_repo("dgr-branch-cli", |repo| {
+        initialize_main_repo(repo);
+        dgr_ok(repo, &["init"]);
+        dgr_ok(repo, &["branch", "feat/auth"]);
+        commit_file(repo, "auth.txt", "auth\n", "feat: auth");
+        dgr_ok(repo, &["branch", "feat/auth-api"]);
+        commit_file(repo, "api.txt", "api\n", "feat: auth api");
+        dgr_ok(repo, &["branch", "feat/auth-api-tests"]);
+        commit_file(repo, "tests.txt", "tests\n", "feat: auth api tests");
+        git_ok(repo, &["checkout", "feat/auth"]);
+
+        let output = dgr_ok(repo, &["branch", "--delete", "feat/auth-api"]);
+        let stdout = strip_ansi(&String::from_utf8(output.stdout).unwrap());
+
+        assert!(stdout.contains("Deleted 'feat/auth-api'. It is no longer tracked by dagger."));
+        assert!(stdout.contains("Returned to 'feat/auth' after deleting."));
+        assert!(stdout.contains("- feat/auth-api-tests onto feat/auth"));
+        assert!(
+            !git_stdout(repo, &["branch", "--list", "feat/auth-api"]).contains("feat/auth-api")
+        );
+        assert_eq!(git_stdout(repo, &["branch", "--show-current"]), "feat/auth");
+        assert_eq!(
+            git_stdout(repo, &["merge-base", "feat/auth", "feat/auth-api-tests"]),
+            git_stdout(repo, &["rev-parse", "feat/auth"])
+        );
+
+        let state = load_state_json(repo);
+        assert!(find_node(&state, "feat/auth-api").is_none());
+        assert!(find_archived_node(&state, "feat/auth-api").is_some());
+        let child = find_node(&state, "feat/auth-api-tests").unwrap();
+        assert_eq!(child["base_ref"], "feat/auth");
+        assert_eq!(
+            child["parent"]["node_id"],
+            find_node(&state, "feat/auth").unwrap()["id"]
+        );
+        assert_eq!(load_operation_json(repo), None);
+    });
+}
+
+#[test]
+fn branch_delete_rejects_current_branch() {
+    with_temp_repo("dgr-branch-cli", |repo| {
+        initialize_main_repo(repo);
+        dgr_ok(repo, &["init"]);
+        dgr_ok(repo, &["branch", "feat/auth"]);
+
+        let output = dgr(repo, &["branch", "--delete", "feat/auth"]);
+
+        assert!(!output.status.success());
+        let stderr = String::from_utf8(output.stderr).unwrap();
+        assert!(stderr.contains(
+            "cannot delete checked-out branch 'feat/auth'; switch to another branch first"
+        ));
+        assert!(git_stdout(repo, &["branch", "--list", "feat/auth"]).contains("feat/auth"));
+    });
+}
+
+#[test]
+fn branch_delete_rejects_trunk_branch() {
+    with_temp_repo("dgr-branch-cli", |repo| {
+        initialize_main_repo(repo);
+        dgr_ok(repo, &["init"]);
+
+        let output = dgr(repo, &["branch", "--delete", "main"]);
+
+        assert!(!output.status.success());
+        let stderr = String::from_utf8(output.stderr).unwrap();
+        assert!(stderr.contains("cannot delete trunk branch 'main'"));
+    });
+}
+
+#[test]
+fn branch_delete_rejects_untracked_branch() {
+    with_temp_repo("dgr-branch-cli", |repo| {
+        initialize_main_repo(repo);
+        dgr_ok(repo, &["init"]);
+        git_ok(repo, &["checkout", "-b", "feat/manual"]);
+        commit_file(repo, "manual.txt", "manual\n", "feat: manual");
+        git_ok(repo, &["checkout", "main"]);
+
+        let output = dgr(repo, &["branch", "--delete", "feat/manual"]);
+
+        assert!(!output.status.success());
+        let stderr = String::from_utf8(output.stderr).unwrap();
+        assert!(stderr.contains("branch 'feat/manual' is not tracked by dagger"));
+        assert!(git_stdout(repo, &["branch", "--list", "feat/manual"]).contains("feat/manual"));
+    });
+}
+
+#[test]
+fn branch_delete_rejects_branch_with_missing_tracked_descendant() {
+    with_temp_repo("dgr-branch-cli", |repo| {
+        initialize_main_repo(repo);
+        dgr_ok(repo, &["init"]);
+        dgr_ok(repo, &["branch", "feat/auth"]);
+        commit_file(repo, "auth.txt", "auth\n", "feat: auth");
+        dgr_ok(repo, &["branch", "feat/auth-api"]);
+        commit_file(repo, "api.txt", "api\n", "feat: auth api");
+        git_ok(repo, &["checkout", "main"]);
+        git_ok(repo, &["branch", "-D", "feat/auth-api"]);
+
+        let output = dgr(repo, &["branch", "--delete", "feat/auth"]);
+
+        assert!(!output.status.success());
+        let stderr = String::from_utf8(output.stderr).unwrap();
+        assert!(
+            stderr
+                .contains("tracked descendants of 'feat/auth' are missing locally: feat/auth-api")
+        );
+        assert!(git_stdout(repo, &["branch", "--list", "feat/auth"]).contains("feat/auth"));
+    });
+}
+
+#[test]
+fn sync_continues_paused_branch_delete_restack() {
+    with_temp_repo("dgr-branch-cli", |repo| {
+        initialize_main_repo(repo);
+        dgr_ok(repo, &["init"]);
+        dgr_ok(repo, &["branch", "feat/auth"]);
+        commit_file(repo, "shared.txt", "parent\n", "feat: auth");
+        dgr_ok(repo, &["branch", "feat/auth-ui"]);
+        commit_file(repo, "shared.txt", "child\n", "feat: auth ui");
+        git_ok(repo, &["checkout", "main"]);
+        commit_file(repo, "shared.txt", "main\n", "feat: trunk");
+
+        let output = dgr(repo, &["branch", "--delete", "feat/auth"]);
+        assert!(!output.status.success());
+        assert!(git_stdout(repo, &["branch", "--list", "feat/auth"]).contains("feat/auth"));
+        assert!(repo.join(".git/rebase-merge").exists() || repo.join(".git/rebase-apply").exists());
+        assert!(active_rebase_head_name(repo).contains("feat/auth-ui"));
+        let operation = load_operation_json(repo).unwrap();
+        assert_eq!(operation["origin"]["type"].as_str(), Some("branch_delete"));
+
+        write_file(repo, "shared.txt", "resolved\n");
+        git_ok(repo, &["add", "shared.txt"]);
+
+        let output = dgr_ok(repo, &["sync", "--continue"]);
+        let stdout = strip_ansi(&String::from_utf8(output.stdout).unwrap());
+
+        assert!(stdout.contains("Deleted 'feat/auth'. It is no longer tracked by dagger."));
+        assert!(stdout.contains("Returned to 'main' after deleting."));
+        assert!(stdout.contains("- feat/auth-ui onto main"));
+        assert!(!git_stdout(repo, &["branch", "--list", "feat/auth"]).contains("feat/auth"));
+        assert_eq!(git_stdout(repo, &["branch", "--show-current"]), "main");
+
+        let state = load_state_json(repo);
+        assert!(find_node(&state, "feat/auth").is_none());
+        let archived = find_archived_node(&state, "feat/auth").unwrap();
+        assert_eq!(archived["archived"], true);
+        let events = load_events_json(repo);
+        assert!(events.iter().any(|event| {
+            event["type"].as_str() == Some("branch_archived")
+                && event["branch_name"].as_str() == Some("feat/auth")
+                && event["reason"]["kind"].as_str() == Some("deleted_by_user")
+        }));
+        let child = find_node(&state, "feat/auth-ui").unwrap();
+        assert_eq!(child["base_ref"], "main");
+        assert_eq!(child["parent"]["kind"], "trunk");
+        assert_eq!(load_operation_json(repo), None);
     });
 }

--- a/tests/pause_guard.rs
+++ b/tests/pause_guard.rs
@@ -83,6 +83,20 @@ fn adopt_rejects_immediately_while_commit_restack_is_paused() {
 }
 
 #[test]
+fn branch_delete_rejects_immediately_while_commit_restack_is_paused() {
+    with_temp_repo("dgr-pause-guard", |repo| {
+        let operation = pause_commit_restack(repo);
+
+        assert_command_rejected_while_commit_is_paused(
+            repo,
+            &["branch", "--delete", "feat/auth"],
+            "branch",
+            &operation,
+        );
+    });
+}
+
+#[test]
 fn merge_rejects_before_rendering_plan_while_commit_restack_is_paused() {
     with_temp_repo("dgr-pause-guard", |repo| {
         let operation = pause_commit_restack(repo);


### PR DESCRIPTION
## Summary
- add `dgr branch --delete <branch>` and `dgr branch -D <branch>`
- restack descendants onto the deleted branch parent before deleting
- support paused branch-delete restacks through `dgr sync --continue`
- record user-initiated deletes with `deleted_by_user` archive reason

## Validation
- `rustup run stable cargo fmt --all --check`
- `cargo check`
- `cargo test`